### PR TITLE
V2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 2.8
 
+## BMView
+
+The methods for registering and managing keyboard shortcuts have moved from `BMWindow` to `BMView` so that any subclass can make use of this functionality.
+
 ## BMCollectionView
 
 Added a new readonly `visibleBounds` property that returns a rect describing the part of the bounds that are visible on screen.
@@ -7,6 +11,31 @@ Added a new readonly `visibleBounds` property that returns a rect describing the
 When using `scrollToSupplementaryViewWithIdentifier` or `scrollToCellAtIndexPath` and not specifying any gravity, the default values will now depend on the cell's position relative to the current bounds, rather that defaulting to top and left.
 
 Resolved an issue in `scrollToSupplementaryViewWithIdentifier` where the default top gravity was set to an improper default value when omitted.
+
+Added support for a new state for cells called highlighting and a series of new properties and method to support this. Cells are highlighted when they are clicked or by using the keyboard arrow keys. The following properties and methods related to this functionality have been added:
+ - A new `highlightedIndexPath` property can be used to set or retrieve the currently highlighted index path.
+ - A new `isCellAtIndexPathHighlighted(_)` method can be used to test if a given index path is highlighted.
+ - A new `keyboardArrowPressed(_, {withEvent})` method is invoked when arrow keys are pressed on the keyboard and can be invoked to simulate an arrow press.
+ - A new `configureKeyboardShortcuts` method is now invoked during initialization to enable cell highlighting via the keyboard. Subclasses may also override this method to add their own keyboard shortcuts.
+
+## BMCollectionViewDelegate
+
+Delegates can now implement the following methods to control and respond to cells being highlighted:
+ - `collectionViewCanHighlightCellAtIndexPath(_, _, {withEvent})` can be used to control whether specific cells may be highlighted or not.
+ - `collectionViewDidHighlightCellAtIndexPath(_, _, {withEvent})` can be used to respond to cells being highlighted.
+ - `collectionViewDidDehighlightCellAtIndexPath(_, _, {withEvent})` can be used to respond to cells being dehighlighted.
+ - `collectionViewShouldScrollToHighlightedCellAtIndexPath(_, _)` is invoked when an off-screen cell is highlighted to determine whether the collection should scroll to reveal that cell.
+
+## BMCollectionViewLayout
+
+The following new methods have been added and may be overriden by layout subclasses to improve keyboard navigation:
+ - `firstIndexPath()` is used to obtain the first visible index path.
+ - `indexPathToTheLeftOfIndexPath(_)` is used to obtain the index path that is visually to the left of a given index path.
+ - `indexPathToTheRightOfIndexPath(_)` is used to obtain the index path that is visually to the right of a given index path.
+ - `indexPathAboveIndexPath(_)` is used to obtain the index path that is visually above a given index path.
+ - `indexPathBelowIndexPath(_)` is used to obtain the index path that is visually below a given index path.
+
+A new `indexPathsFromIndexPath(_, {toIndexPath})` method can be used to obtain a list of index paths that are visually between two index paths.
 
 # 2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Delegates can now implement the following methods to control and respond to cell
  - `collectionViewDidDehighlightCellAtIndexPath(_, _, {withEvent})` can be used to respond to cells being dehighlighted.
  - `collectionViewShouldScrollToHighlightedCellAtIndexPath(_, _)` is invoked when an off-screen cell is highlighted to determine whether the collection should scroll to reveal that cell.
 
+Resolved an issue where several event arguments were declared as jQuery events when in fact they were standard events.
+
 ## BMCollectionViewLayout
 
 The following new methods have been added and may be overriden by layout subclasses to improve keyboard navigation:
@@ -36,6 +38,10 @@ The following new methods have been added and may be overriden by layout subclas
  - `indexPathBelowIndexPath(_)` is used to obtain the index path that is visually below a given index path.
 
 A new `indexPathsFromIndexPath(_, {toIndexPath})` method can be used to obtain a list of index paths that are visually between two index paths.
+
+## BMKeyboardShortcut
+
+This type is now properly included in the definitions file.
 
 # 2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Added support for a new state for cells called highlighting and a series of new 
 ## BMCollectionViewDelegate
 
 Delegates can now implement the following methods to control and respond to cells being highlighted:
+ - `collectionViewShouldHighlightCellForArrowKey(_, _, {withEvent})` can be used to control when keyboard events are processed.
  - `collectionViewCanHighlightCellAtIndexPath(_, _, {withEvent})` can be used to control whether specific cells may be highlighted or not.
  - `collectionViewDidHighlightCellAtIndexPath(_, _, {withEvent})` can be used to respond to cells being highlighted.
  - `collectionViewDidDehighlightCellAtIndexPath(_, _, {withEvent})` can be used to respond to cells being dehighlighted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.8
+
+## BMCollectionView
+
+Added a new readonly `visibleBounds` property that returns a rect describing the part of the bounds that are visible on screen.
+
+When using `scrollToSupplementaryViewWithIdentifier` or `scrollToCellAtIndexPath` and not specifying any gravity, the default values will now depend on the cell's position relative to the current bounds, rather that defaulting to top and left.
+
+Resolved an issue in `scrollToSupplementaryViewWithIdentifier` where the default top gravity was set to an improper default value when omitted.
+
 # 2.7.1
 
 ## BMMonacoCodeEditor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 # 2.8
 
+## BMAnimationContext
+
+Animations will no longer run in slow-motion when triggered from an event while the shift key was pressed.
+
 ## BMView
 
-The methods for registering and managing keyboard shortcuts have moved from `BMWindow` to `BMView` so that any subclass can make use of this functionality.
+The methods for registering and managing keyboard shortcuts have moved from `BMWindow` to `BMView` so that any subclass can make use of this functionality. Improved performance when registering a large number of keyboard shortcuts.
+
+Added two new static methods `registerKeyboardShortcut(_, {forNode})` and `unregisterKeyboardShortcut(_, {forNode})` that can be used to add keyboard shortcuts to elements without creating a view for them.
+
+## BMMenu
+
+While a menu is open, menu items can now be navigated using the keyboard up and down arrow keys and can be selected using the return or spacebar keys. Additionally it can be closed with the escape key.
 
 ## BMCollectionView
 
@@ -40,9 +50,21 @@ The following new methods have been added and may be overriden by layout subclas
 
 A new `indexPathsFromIndexPath(_, {toIndexPath})` method can be used to obtain a list of index paths that are visually between two index paths.
 
+The `BMCollectionViewFlowLayout`, `BMCollectionViewMasonryLayout` and `BMCollectionViewTileLayout` classes each provide their own specific implementation of those methods.
+
 ## BMKeyboardShortcut
 
 This type is now properly included in the definitions file.
+
+## BMAlertPopup
+
+When dismissed, the element that was focused when the alert was shown will acquire focus again.
+
+## BMTextField
+
+Resolved various bugs with this class.
+
+A new `maxSuggestions` property can be set to control how many entries appear in the autocomplete menu.
 
 # 2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 2.8
 
+## Generic
+
+Resolved a typo with the `BMButton` CSS class that prevented its active state rules from applying.
+
+Added the `Control` and `Escape` properties to `BMHTMLEntity`.
+
 ## BMAnimationContext
 
 Animations will no longer run in slow-motion when triggered from an event while the shift key was pressed.
@@ -9,6 +15,8 @@ Animations will no longer run in slow-motion when triggered from an event while 
 The methods for registering and managing keyboard shortcuts have moved from `BMWindow` to `BMView` so that any subclass can make use of this functionality. Improved performance when registering a large number of keyboard shortcuts.
 
 Added two new static methods `registerKeyboardShortcut(_, {forNode})` and `unregisterKeyboardShortcut(_, {forNode})` that can be used to add keyboard shortcuts to elements without creating a view for them.
+
+When setting the `layoutQueue` property, any pending layout pass will now occur on the new layout queue.
 
 ## BMMenu
 
@@ -22,11 +30,18 @@ When using `scrollToSupplementaryViewWithIdentifier` or `scrollToCellAtIndexPath
 
 Resolved an issue in `scrollToSupplementaryViewWithIdentifier` where the default top gravity was set to an improper default value when omitted.
 
+Resolved an issue when using nested collection views that all had drag & drop enabled which would cause multiple collection views to start their drag & drop operation at the same when initiating it from a cell in one of the nested collection views. Now, starting a drag & drop from one collection view will prevent any parent collection views from starting their own drag & drop.
+
+Collection View will now ignore clicks originating on content editable elements, in addition to its previous exclusion list.
+
 Added support for a new state for cells called highlighting and a series of new properties and method to support this. Cells are highlighted when they are clicked or by using the keyboard arrow keys. The following properties and methods related to this functionality have been added:
  - A new `highlightedIndexPath` property can be used to set or retrieve the currently highlighted index path.
  - A new `isCellAtIndexPathHighlighted(_)` method can be used to test if a given index path is highlighted.
  - A new `keyboardArrowPressed(_, {withEvent})` method is invoked when arrow keys are pressed on the keyboard and can be invoked to simulate an arrow press.
- - A new `configureKeyboardShortcuts` method is now invoked during initialization to enable cell highlighting via the keyboard. Subclasses may also override this method to add their own keyboard shortcuts.
+ - A new `configureKeyboardShortcuts` method is now invoked during initialization to enable cell highlighting via the keyboard. Subclasses may also override this method to add their own keyboard shortcuts. A similar `disableKeyboardShortcuts` method is invoked when keyboard navigation is disabled.
+ - A new `supportsKeyboardNavigation` property, with a default value of `YES` can be used to control whether keyboard navigation is enabled or not.
+
+When creating cells, collection view will now properly handle layout changes that occur in the cell's initializer.
 
 ## BMCollectionViewDelegate
 
@@ -52,9 +67,17 @@ A new `indexPathsFromIndexPath(_, {toIndexPath})` method can be used to obtain a
 
 The `BMCollectionViewFlowLayout`, `BMCollectionViewMasonryLayout` and `BMCollectionViewTileLayout` classes each provide their own specific implementation of those methods.
 
+## BMCollectionViewFlowLayout
+
+Resolves an issue with `BMCollectionViewFlowLayoutGravity`, `BMCollectionViewFlowLayoutAlignment` and `BMCollectionViewFlowLayoutOrientation` that had improper type definitions.
+
 ## BMKeyboardShortcut
 
 This type is now properly included in the definitions file.
+
+Added a new `serializedKeyboardShortcutWithTargetID(_)` method that can be used to obtain a plain object representing the keyboard shortcut that can be stringified. A new static `keyboardShortcutWithSerializedKeyboardShortcut(_, {targetID})` method and a new `initWithSerializedKeyboardShortcut(_, {targetID})` initializer can be used to obtain back a keyboard shortcut from a plain object representation.
+
+Added a new `initWithKeyboardEvent(_, {target, action, preventsDefault})` initializer and a new `keyboardShortcutWithKeyboardEvent(_, {target, action, preventsDefault})` static method that can be used to obtain a keyboard shortcut from a keyboard event.
 
 ## BMAlertPopup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ Added a new `serializedKeyboardShortcutWithTargetID(_)` method that can be used 
 
 Added a new `initWithKeyboardEvent(_, {target, action, preventsDefault})` initializer and a new `keyboardShortcutWithKeyboardEvent(_, {target, action, preventsDefault})` static method that can be used to obtain a keyboard shortcut from a keyboard event.
 
+When keyboard shortcuts are triggered, the action method will now also receive a second parameter containing the triggered shortcut object. The signature of the method becomes `(_, {forKeyboardShortcut})`.
+
 ## BMAlertPopup
 
 When dismissed, the element that was focused when the alert was shown will acquire focus again.

--- a/DTSGen.js
+++ b/DTSGen.js
@@ -1148,8 +1148,10 @@ function typeScriptDocumentationWithDocumentation(documentation) {
     if (!documentation) return '';
 
     documentation = documentation.replace(/<code>/g, '\`').replace(/<\/code>/g, '\`');
+    documentation = documentation.replace(/<pre>/g, '\`\`\`').replace(/<\/pre>/g, '\`\`\`');
     documentation = documentation.replace(/<b>/g, '__').replace(/<\/b>/g, '__');
     documentation = documentation.replace(/<ul>/g, '\n *').replace(/<\/ul>/g, '\n *');
+    documentation = documentation.replace(/<ol>/g, '\n *').replace(/<\/ol>/g, '\n *');
     documentation = documentation.replace(/<li>(.*)<\/li>/g, (match, item) => ' * ' + item);
     documentation = documentation.replace(/<li>(.*)/g, (match, item) => ' * ' + item);
     documentation = documentation.replace(/(.*)<\/li>/g, (match, item) => item);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -125,7 +125,8 @@ const DTSFiles = [
     'BMWindow/BMToolWindow.js', 
     'BMWindow/BMWindowDelegate.js', 
     'BMWindow/BMPopover/BMPopover.js', 
-    'BMWindow/BMConfirmationPopup.js', 
+    'BMWindow/BMConfirmationPopup.js',
+    'BMWindow/BMKeyboardShortcut.js', 
     'BMCodeEditor/BMCodeEditor.js', 
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bm-core-ui",
-    "version": "2.6.11",
+    "version": "2.7.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-core-ui",
-            "version": "2.6.11",
+            "version": "2.7.1",
             "license": "MIT",
             "dependencies": {
                 "kiwi.js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-core-ui",
     "packageName": "BMCoreUI",
     "moduleName": "BMCoreUI",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "description": "A collection of reusable UI classes.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -4131,7 +4131,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
             }
 
             // If the cell was highlighted, prevent the default action for keyboard events
-            if (event instanceof KeyboardEvent) {
+            if (event && event instanceof KeyboardEvent) {
                 event.preventDefault();
             }
         }

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -3920,6 +3920,11 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	cellWasClicked: function (cell, options) {
 		if (options && options.withEvent) options.withEvent._BMOriginalTarget = cell.node;
 
+        // Acquire focus if not already owned
+        if (document.activeElement != this.node) {
+            this.node.focus();
+        }
+
 		// Forward this event to the delegate, giving it a chance to handle the event
 		var eventHandled = NO;
 		if (this.delegate && this.delegate.collectionViewCellWasClicked) {
@@ -3980,6 +3985,11 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	cellWasDoubleClicked: function (cell, options) {
 		if (options && options.withEvent) options.withEvent._BMOriginalTarget = cell.node;
 
+        // Acquire focus if not already owned
+        if (document.activeElement != this.node) {
+            this.node.focus();
+        }
+
 		// Forward this event to the delegate, giving it a chance to handle the event
 		var eventHandled = NO;
 		if (this.delegate && this.delegate.collectionViewCellWasDoubleClicked) {
@@ -3996,6 +4006,11 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	 */
 	cellWasLongClicked: function (cell, options) {
 		if (options && options.withEvent) options.withEvent._BMOriginalTarget = cell.node;
+
+        // Acquire focus if not already owned
+        if (document.activeElement != this.node) {
+            this.node.focus();
+        }
 		
 		// Forward this event to the delegate, giving it a chance to handle the event
 		var eventHandled = NO;
@@ -5704,41 +5719,6 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 			return BMAnimateWithBlock(_ => {
 				self.scrollOffset = offset;
 			}, {duration: 300});
-
-			/*
-			// Scrolling is performed differently based on whether iScroll is used or not
-			if (this.iScroll) {
-				this.iScroll.scrollTo(-(offset.x | 0), -(offset.y | 0), 300, IScroll.utils.ease.quadratic);
-				
-				// For iScroll, the layout should be refreshed after the animation
-				var self = this;
-				window.setTimeout(function () {
-					self._handleNewScrollFromEvent({x: offset.x, y: offset.y});
-				}, 316);
-			}
-			else {
-				// For native scrolling, jQuery animations are used instead
-				var startingPoint = this.scrollOffset.copy();
-				var targetPoint = offset;
-				var self = this;
-				this._container.velocity({
-					tween: 1
-				}, {
-					duration: 300,
-					queue: NO,
-					progress: function (elements, completion) {
-						self._container[0].scrollLeft = ((targetPoint.x - startingPoint.x) * completion + startingPoint.x) | 0;
-						self._container[0].scrollTop = ((targetPoint.y - startingPoint.y) * completion + startingPoint.y) | 0;
-
-						self._handleNewScrollFromEvent(null);
-					},
-					complete: function () {
-
-						self._handleNewScrollFromEvent(null);
-					}
-				});
-			}
-			*/
 		}
 		else {
 			// Scrolling is performed differently based on whether iScroll is used or not

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -515,6 +515,13 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	 */
     _bounds: undefined, // <BMRect>
     get bounds() { return this._bounds; },
+
+	/**
+	 * A rect that represents the part of the bounds that are visible on screen.
+	 */
+	get visibleBounds() { // <BMRect>
+		return new BMRect(BMPointMake(this._bounds.origin.x + this._offscreenBufferSize, this._bounds.origin.y + this._offscreenBufferSize), this._frame.size.copy());
+	},
     
     /**
 	 * The number of pixels by which to extend the bounds to preload layout attributes and render off-screen elements.

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -5555,10 +5555,10 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				visibleBounds = this.visibleBounds;
 
 				if (rect.origin.y > visibleBounds.bottom) {
-					verticalGravity = BMCollectionViewScrollingGravityVertical.Top;
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Bottom;
 				}
 				else if (rect.bottom < visibleBounds.origin.y) {
-					verticalGravity = BMCollectionViewScrollingGravityVertical.Bottom;
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Top;
 				}
 				else {
 					verticalGravity = BMCollectionViewScrollingGravityVertical.Center;
@@ -5569,10 +5569,10 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				visibleBounds = visibleBounds || this.visibleBounds;
 
 				if (rect.origin.x > visibleBounds.right) {
-					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
 				}
 				else if (rect.right < visibleBounds.origin.x) {
-					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
 				}
 				else {
 					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
@@ -5615,10 +5615,10 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				visibleBounds = this.visibleBounds;
 
 				if (rect.origin.y > visibleBounds.bottom) {
-					verticalGravity = BMCollectionViewScrollingGravityVertical.Top;
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Bottom;
 				}
 				else if (rect.bottom < visibleBounds.origin.y) {
-					verticalGravity = BMCollectionViewScrollingGravityVertical.Bottom;
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Top;
 				}
 				else {
 					verticalGravity = BMCollectionViewScrollingGravityVertical.Center;
@@ -5629,10 +5629,10 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				visibleBounds = visibleBounds || this.visibleBounds;
 
 				if (rect.origin.x > visibleBounds.right) {
-					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
 				}
 				else if (rect.right < visibleBounds.origin.x) {
-					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
 				}
 				else {
 					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
@@ -5670,7 +5670,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 			offset.y = rect.origin.y + rect.size.height / 2 - this.frame.size.height / 2;
 		}
 		else if (options.withVerticalGravity == BMCollectionViewScrollingGravityVertical.Bottom) {
-			offset.y = rect.origin.y + rect.size.height - this.frame.size.height / 2;
+			offset.y = rect.origin.y + rect.size.height - this.frame.size.height;
 		}
 		
 		// Then the horizontal X offset
@@ -5681,7 +5681,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 			offset.x = rect.origin.x + rect.size.width / 2 - this.frame.size.width / 2;
 		}
 		else if (options.withVerticalGravity == BMCollectionViewScrollingGravityHorizontal.Right) {
-			offset.x = rect.origin.x + rect.size.width - this.frame.size.width / 2;
+			offset.x = rect.origin.x + rect.size.width - this.frame.size.width;
 		}
 		
 		// Scroll to the offset point

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -4097,12 +4097,12 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 
     /**
      * Highlights the given index path.
-     * @param indexPath <BMIndexPath>       The index path to highlight.
+     * @param indexPath <BMIndexPath>           The index path to highlight.
      * {
-     *  @param withEvent <UIEvent>          The event that triggered this action. 
+     *  @param withEvent <UIEvent, nullable>    The event that triggered this action, if any. 
      * }
      */
-    _highlightIndexPath(indexPath, {withEvent: event}) {
+    _highlightIndexPath(indexPath, {withEvent: event} = {withEvent: undefined}) {
         const currentHighlight = this._highlightedIndexPath;
 
 		this._highlightedIndexPath = indexPath;

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -4289,7 +4289,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		}
 
         if (this._highlightedIndexPath) {
-            this._highlightedIndexPath = this.dataSet.indexPathForObject(this._highlightedIndexPath);
+            this._highlightedIndexPath = this.dataSet.indexPathForObject(this._highlightedIndexPath.object);
         }
 	},
 	

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -2233,8 +2233,8 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		else {
 			// Otherwise use the cell's own CSS size for this purpose
 			size = BMSizeMake(
-				cell._variables[BMLayoutAttribute.Width].value() | cell.node.offsetWidth, 
-				cell._variables[BMLayoutAttribute.Height].value() | cell.node.offsetHeight
+				cell._variables[BMLayoutAttribute.Width].value() || cell.node.offsetWidth, 
+				cell._variables[BMLayoutAttribute.Height].value() || cell.node.offsetHeight
 			);
 		}
 

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -4149,6 +4149,20 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		let nextIndexPath = this._highlightedIndexPath;
 		const event = args && args.withEvent;
 
+        if (event) {
+            // If this triggered by an event, ask the delegate if collection view should process this event
+            let canProcess = YES;
+
+            if (this.delegate && this.delegate.collectionViewShouldHighlightCellForArrowKey) {
+                canProcess = this.delegate.collectionViewShouldHighlightCellForArrowKey(this, arrow, {withEvent: event});
+            }
+
+            // If the delegate disallows processing this event, stop
+            if (!canProcess) {
+                return;
+            }
+        }
+
 		do {
 			const startingIndexPath = nextIndexPath;
 

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -2386,7 +2386,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		node.style.cssText = "position: absolute; left: 0px; top: 0px; visibility: hidden; overflow: visible;";
 
 		var cell = Object.create(cellClass.prototype).initWithCollectionView(this, {reuseIdentifier: identifier, node: node, kind: BMCollectionViewLayoutAttributesType.Cell});
-		cell._layoutQueue = this._cellLayoutQueue;
+		cell.layoutQueue = this._cellLayoutQueue;
 		//BMCollectionViewCellMakeForCollectionView(this, {withReuseIdentifier: identifier});
 		
 
@@ -3673,7 +3673,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	    // Otherwise construct a new one
 		var cellClass = this._supplementaryViewClasses[identifier] || this._cellClass;
 		var cell = Object.create(cellClass.prototype).initWithCollectionView(this, {reuseIdentifier: identifier, node: node, kind: BMCollectionViewLayoutAttributesType.SupplementaryView});
-		cell._layoutQueue = this._cellLayoutQueue;
+		cell.layoutQueue = this._cellLayoutQueue;
 		
 		// When using custom classes, it is no longer the data set object's responsibility to provide the contents for the cell
 	    if (cellClass == BMCollectionViewCell) cell.element.append(this._dataSet.contentsForSupplementaryViewWithIdentifier(identifier));

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -4059,7 +4059,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
             case 'ArrowUp':
             case 'ArrowRight':
             case 'ArrowDown':
-                this.keyboardArrowPressed(event.keyCode, {withEvent: event});
+                this.keyboardArrowPressed(event.code, {withEvent: event});
                 break;
         }
     },

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -2460,6 +2460,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				event.target.parentNode.nodeName == 'BUTTON' || event.target.parentNode.nodeName == 'INPUT' || event.target.parentNode.nodeName == 'LABEL' ||
 				event.target.classList.contains('BMCollectionViewCellEventHandler') || event.target.parentNode.classList.contains('BMCollectionViewCellEventHandler') ||
 				event.target.classList.contains('widget-foldingpanel-header') ||
+                event.target.hasAttribute('contenteditable') ||
 				// This a specific Thingworx workaround that depends on jQuery
 				(window.$ ? window.$(event.target).parents('.widget-dhxdropdown').length : false)) {
 			    return;

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -5375,7 +5375,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		var rect = this._layout.rectWithScrollingPositionOfSupplementaryViewWithIdentifier(identifier, {atIndexPath: options.atIndexPath});
 		
 		if (rect) {
-			var verticalGravity = options.verticalGravity || BMCollectionViewScrollingGravityHorizontal.Top;
+			var verticalGravity = options.verticalGravity || BMCollectionViewScrollingGravityVertical.Top;
 			var horizontalGravity = options.horizontalGravity || BMCollectionViewScrollingGravityHorizontal.Left;
 			var animated = options.animated;
 			return this.scrollToRect(rect, {withVerticalGravity: verticalGravity, horizontalGravity: horizontalGravity, animated: animated});

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -5343,10 +5343,40 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	 */
 	scrollToCellAtIndexPath: function (indexPath, options) {
 		var rect = this._layout.rectWithScrollingPositionOfCellAtIndexPath(indexPath);
+		let visibleBounds;
 		
 		if (rect) {
-			var verticalGravity = (options && options.withVerticalGravity) || BMCollectionViewScrollingGravityVertical.Top;
-			var horizontalGravity = (options && options.horizontalGravity) || BMCollectionViewScrollingGravityHorizontal.Left;
+			var verticalGravity = (options && options.withVerticalGravity);
+			var horizontalGravity = (options && options.horizontalGravity);
+
+			if (!verticalGravity) {
+				visibleBounds = this.visibleBounds;
+
+				if (rect.origin.y > visibleBounds.bottom) {
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Top;
+				}
+				else if (rect.bottom < visibleBounds.origin.y) {
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Bottom;
+				}
+				else {
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Center;
+				}
+			}
+
+			if (!horizontalGravity) {
+				visibleBounds = visibleBounds || this.visibleBounds;
+
+				if (rect.origin.x > visibleBounds.right) {
+					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
+				}
+				else if (rect.right < visibleBounds.origin.x) {
+					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
+				}
+				else {
+					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
+				}
+			}
+
 			var animated = options && options.animated;
 			return this.scrollToRect(rect, {withVerticalGravity: verticalGravity, horizontalGravity: horizontalGravity, animated: animated});
 		}
@@ -5360,10 +5390,10 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	 * @param identifier <String>														The supplementary view's type identifier.
 	 * {
 	 *	@param atIndexPath <BMIndexPath<T>>												The index path of the supplementary view to scroll to.
-	 *	@param verticalGravity <BMCollectionViewScrollingGravityVertical, nullable>		Defaults to BMCollectionViewScrollingGravityVertical.Top. The scroll gravity to use, 
+	 *	@param verticalGravity <BMCollectionViewScrollingGravityVertical, nullable>		Defaults to a value depending on where the cell is positioned. The scroll gravity to use, 
 	 *																					which controls where on the screen the cell should appear after the scrolling operation
 	 *																					completes.
-	 *	@param horizontalGravity <BMCollectionViewScrollingGravityHorizontal, nullable>	Defaults to BMCollectionViewScrollingGravityHorizontal.Left. The scroll gravity to use, 
+	 *	@param horizontalGravity <BMCollectionViewScrollingGravityHorizontal, nullable>	Defaults to a value depending on where the cell is positioned. The scroll gravity to use, 
 	 *																					which controls where on the screen the cell should appear after the scrolling operation
 	 *																					completes.
 	 *	@param animated <Boolean, nullable>												Defaults to NO. If set to YES, the scroll will be animated, otherwise it will be 
@@ -5373,10 +5403,40 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	 */
 	scrollToSupplementaryViewWithIdentifier: function (identifier, options) {
 		var rect = this._layout.rectWithScrollingPositionOfSupplementaryViewWithIdentifier(identifier, {atIndexPath: options.atIndexPath});
+		let visibleBounds;
 		
 		if (rect) {
-			var verticalGravity = options.verticalGravity || BMCollectionViewScrollingGravityVertical.Top;
-			var horizontalGravity = options.horizontalGravity || BMCollectionViewScrollingGravityHorizontal.Left;
+			var verticalGravity = options.verticalGravity;
+			var horizontalGravity = options.horizontalGravity;
+
+			if (!verticalGravity) {
+				visibleBounds = this.visibleBounds;
+
+				if (rect.origin.y > visibleBounds.bottom) {
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Top;
+				}
+				else if (rect.bottom < visibleBounds.origin.y) {
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Bottom;
+				}
+				else {
+					verticalGravity = BMCollectionViewScrollingGravityVertical.Center;
+				}
+			}
+
+			if (!horizontalGravity) {
+				visibleBounds = visibleBounds || this.visibleBounds;
+
+				if (rect.origin.x > visibleBounds.right) {
+					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
+				}
+				else if (rect.right < visibleBounds.origin.x) {
+					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
+				}
+				else {
+					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
+				}
+			}
+
 			var animated = options.animated;
 			return this.scrollToRect(rect, {withVerticalGravity: verticalGravity, horizontalGravity: horizontalGravity, animated: animated});
 		}

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -3930,7 +3930,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		if (eventHandled) return;
 
         // The default behaviour when clicking cells is to highlight them
-        if (this._highlightedIndexPath && this._highlightedIndexPath.isLooselyEqualToIndexPath(cell.indexPath, {usingComparator: this.identityComparator})) {
+        if (this._highlightedIndexPath && !this._highlightedIndexPath.isLooselyEqualToIndexPath(cell.indexPath, {usingComparator: this.identityComparator})) {
             let canHighlight = YES;
             if (this.delegate && this.delegate.collectionViewCanHighlightCellAtIndexPath) {
                 canHighlight = this.delegate.collectionViewCanHighlightCellAtIndexPath(this, cell.indexPath, {withEvent: options.withEvent});
@@ -4103,7 +4103,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
             const cell = this.cellAtIndexPath(indexPath);
     
             // If the newly highlighted index path isn't visible on screen, attempt to scroll to it
-            if (!cell || !cell._attributes.frame.intersectsRect(this._bounds)) {
+            if (!cell || !cell._attributes.frame.intersectsRect(this.visibleBounds)) {
                 let shouldScroll = YES;
     
                 if (this.delegate && this.delegate.collectionViewShouldScrollToHighlightedCellAtIndexPath) {
@@ -4113,6 +4113,11 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
                 if (shouldScroll) {
                     this.scrollToCellAtIndexPath(indexPath, {animated: YES});
                 }
+            }
+
+            // If the cell was highlighted, prevent the default action for keyboard events
+            if (event instanceof KeyboardEvent) {
+                event.preventDefault();
             }
         }
 
@@ -5564,13 +5569,13 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				visibleBounds = visibleBounds || this.visibleBounds;
 
 				if (rect.origin.x > visibleBounds.right) {
-					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
 				}
 				else if (rect.right < visibleBounds.origin.x) {
-					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
 				}
 				else {
-					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
 				}
 			}
 
@@ -5624,13 +5629,13 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				visibleBounds = visibleBounds || this.visibleBounds;
 
 				if (rect.origin.x > visibleBounds.right) {
-					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Left;
 				}
 				else if (rect.right < visibleBounds.origin.x) {
-					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Right;
 				}
 				else {
-					verticalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
+					horizontalGravity = BMCollectionViewScrollingGravityHorizontal.Center;
 				}
 			}
 

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -2564,16 +2564,16 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		// to fire even after the touch point has moved outside of the element
 		// Because of this, mousemove is attached to window for the duration of a click and then released at the end
 		cell.mousemoveHandler = function (event) {
-			if (_BMCoreUIIsDragging) return void (event.preventDefault(), event.stopPropagation());
-			if (canDrag) event.preventDefault();
-			event.originalEvent = event;
-			const which = event.which || event.button;
-
             // If this event was already handled, stop processing
             if (event.BM_Handled) {
                 cancelProcessing();
                 return;
             }
+
+			if (_BMCoreUIIsDragging) return void (event.preventDefault(), event.stopPropagation());
+			if (canDrag) event.preventDefault();
+			event.originalEvent = event;
+			const which = event.which || event.button;
 
 		    // Only handle move events here while the mouse is pressed
 		    if (!cellEventIsMouseDown) return;

--- a/src/BMCollectionView/BMCollectionViewDelegate.js
+++ b/src/BMCollectionView/BMCollectionViewDelegate.js
@@ -111,6 +111,20 @@ BMCollectionViewDelegate.prototype = {
 	collectionViewDidDeselectCellAtIndexPath: function (collectionView, indexPath) {},
 
 	/**
+	 * Invoked by the collection view whenever any arrow key is pressed to determine if it should process that event and highlight
+	 * an appropriate cell.
+	 * 
+	 * Delegates can implement this method to control when keyboard events should be handled, for example to disallow handling the
+	 * left and right arrow keys when the event originates from an input element.
+	 * @param collectionView <BMCollectionView>		The calling collection view.
+	 * @param key <String>							The code of the key that was pressed.
+	 * {
+	 * 	@param withEvent <KeyboardEvent>			The keyboard event that triggered this action.
+	 * }
+	 */
+	collectionViewShouldHighlightCellForArrowKey: function (collectionView, key, args) {},
+
+	/**
 	 * Invoked by the collection view to verify if a cell can be highlighted.
 	 * 
 	 * If this method is not implemented by the delegate object, the collection view will assume that any cell may be highlighted.

--- a/src/BMCollectionView/BMCollectionViewDelegate.js
+++ b/src/BMCollectionView/BMCollectionViewDelegate.js
@@ -129,7 +129,7 @@ BMCollectionViewDelegate.prototype = {
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param indexPath <BMIndexPath>				The cell's index path or `undefined` if the highlighted index path was cleared.
 	 * {
-	 * 	@param widthEvent <Event, nullable>			If the cell was highlighted because of an event, this represents the event
+	 * 	@param withEvent <Event, nullable>			If the cell was highlighted because of an event, this represents the event
 	 * 												for which the cell was highlighted.
 	 * }
 	 */
@@ -140,7 +140,7 @@ BMCollectionViewDelegate.prototype = {
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param indexPath <BMIndexPath>				The cell's index path.
 	 * {
-	 * 	@param widthEvent <Event, nullable>			If the cell was dehighlighted because of an event, this represents the event
+	 * 	@param withEvent <Event, nullable>			If the cell was dehighlighted because of an event, this represents the event
 	 * 												for which the cell was dehighlighted.
 	 * }
 	 */

--- a/src/BMCollectionView/BMCollectionViewDelegate.js
+++ b/src/BMCollectionView/BMCollectionViewDelegate.js
@@ -115,9 +115,9 @@ BMCollectionViewDelegate.prototype = {
 	 * 
 	 * If this method is not implemented by the delegate object, the collection view will assume that any cell may be highlighted.
 	 * @param collectionView <BMCollectionView>		The calling collection view.
-	 * @param indexPath <BMIndexPath>				The cell's index path.
+	 * @param indexPath <BMIndexPath, nullable>		The cell's index path or `undefined` if the highlighted index path should be cleared.
 	 * {
-	 * 	@param forEvent <Event, nullable>			If the cell should be highlighted because of an event, this represents the event
+	 * 	@param withEvent <Event, nullable>			If the cell should be highlighted because of an event, this represents the event
 	 * 												for which the cell should be highlighted.
 	 * }
 	 * @return <Boolean>							`YES` if the cell can be highlighted, `NO` otherwise.
@@ -127,21 +127,32 @@ BMCollectionViewDelegate.prototype = {
 	/**
 	 * Invoked by the collection view whenever any cell was highlighted.
 	 * @param collectionView <BMCollectionView>		The calling collection view.
-	 * @param indexPath <BMIndexPath>				The cell's index path.
+	 * @param indexPath <BMIndexPath>				The cell's index path or `undefined` if the highlighted index path was cleared.
 	 * {
-	 * 	@param forEvent <Event, nullable>			If the cell was highlighted because of an event, this represents the event
+	 * 	@param widthEvent <Event, nullable>			If the cell was highlighted because of an event, this represents the event
 	 * 												for which the cell was highlighted.
 	 * }
 	 */
 	collectionViewDidHighlightCellAtIndexPath: function (collectionView, indexPath, args) {},
 
 	/**
+	 * Invoked by the collection view whenever any cell is no longer highlighted.
+	 * @param collectionView <BMCollectionView>		The calling collection view.
+	 * @param indexPath <BMIndexPath>				The cell's index path.
+	 * {
+	 * 	@param widthEvent <Event, nullable>			If the cell was dehighlighted because of an event, this represents the event
+	 * 												for which the cell was dehighlighted.
+	 * }
+	 */
+	collectionViewDidDehighlightCellAtIndexPath: function (collectionView, indexPath, args) {},
+
+	/**
 	 * Invoked by a collection view after highlighting a cell that it is not visible on screen to determine
 	 * if it should scroll to reveal that cell.
 	 * 
 	 * When this method is not implemented, the default behaviour is to scroll to off-screen cells that are highlighted.
-	 * @param collectionView 		The calling collection view.
-	 * @param indexPath 			The index path that was just highlighted.
+	 * @param collectionView <BMCollectionView> 		The calling collection view.
+	 * @param indexPath <BMIndexPath>			        The index path that was just highlighted.
 	 */
 	collectionViewShouldScrollToHighlightedCellAtIndexPath: function (collectionView, indexPath) {},
 

--- a/src/BMCollectionView/BMCollectionViewDelegate.js
+++ b/src/BMCollectionView/BMCollectionViewDelegate.js
@@ -193,7 +193,7 @@ BMCollectionViewDelegate.prototype = {
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param cell <BMCollectionViewCell>			The cell that triggered this event.
 	 * {
-	 *	@param withEvent <$event>					The jQuery event that triggered this action.
+	 *	@param withEvent <UIEvent>					The event that triggered this action.
 	 * }
 	 * @return <Boolean, nullable>					Defaults to NO. If set to YES the collection view will track double clicks for this event.
 	 */
@@ -208,7 +208,7 @@ BMCollectionViewDelegate.prototype = {
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param cell <BMCollectionViewCell>			The cell that triggered this event.
 	 * {
-	 *	@param withEvent <$event>					The jQuery event that triggered this action.
+	 *	@param withEvent <UIEvent>					The event that triggered this action.
 	 * }
 	 * @return <Boolean, nullable>					Defaults to NO. If set to YES the default actions will be suppressed for this event.
 	 */
@@ -222,7 +222,7 @@ BMCollectionViewDelegate.prototype = {
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param cell <BMCollectionViewCell>			The cell that triggered this event.
 	 * {
-	 *	@param withEvent <$event>					The jQuery event that triggered this action.
+	 *	@param withEvent <UIEvent>					The event that triggered this action.
 	 * }
 	 * @return <Boolean, nullable>					Defaults to NO. If set to YES the default actions will be suppressed for this event.
 	 */
@@ -236,7 +236,7 @@ BMCollectionViewDelegate.prototype = {
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param cell <BMCollectionViewCell>			The cell that triggered this event.
 	 * {
-	 *	@param withEvent <$event>					The jQuery event that triggered this action.
+	 *	@param withEvent <UIEvent>					The event that triggered this action.
 	 * }
 	 * @return <Boolean, nullable>					Defaults to NO. If set to YES the default actions will be suppressed for this event.
 	 */
@@ -251,7 +251,7 @@ BMCollectionViewDelegate.prototype = {
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param cell <BMCollectionViewCell>			The cell that triggered this event.
 	 * {
-	 *	@param withEvent <$event>					The jQuery event that triggered this action.
+	 *	@param withEvent <UIEvent>					The event that triggered this action.
 	 * }
 	 * @return <Boolean, nullable>					Defaults to NO. If set to YES the default actions will be suppressed for this event.
 	 */

--- a/src/BMCollectionView/BMCollectionViewDelegate.js
+++ b/src/BMCollectionView/BMCollectionViewDelegate.js
@@ -111,6 +111,41 @@ BMCollectionViewDelegate.prototype = {
 	collectionViewDidDeselectCellAtIndexPath: function (collectionView, indexPath) {},
 
 	/**
+	 * Invoked by the collection view to verify if a cell can be highlighted.
+	 * 
+	 * If this method is not implemented by the delegate object, the collection view will assume that any cell may be highlighted.
+	 * @param collectionView <BMCollectionView>		The calling collection view.
+	 * @param indexPath <BMIndexPath>				The cell's index path.
+	 * {
+	 * 	@param forEvent <Event, nullable>			If the cell should be highlighted because of an event, this represents the event
+	 * 												for which the cell should be highlighted.
+	 * }
+	 * @return <Boolean>							`YES` if the cell can be highlighted, `NO` otherwise.
+	 */
+	collectionViewCanHighlightCellAtIndexPath: function (collectionView, indexPath, args) {},
+
+	/**
+	 * Invoked by the collection view whenever any cell was highlighted.
+	 * @param collectionView <BMCollectionView>		The calling collection view.
+	 * @param indexPath <BMIndexPath>				The cell's index path.
+	 * {
+	 * 	@param forEvent <Event, nullable>			If the cell was highlighted because of an event, this represents the event
+	 * 												for which the cell was highlighted.
+	 * }
+	 */
+	collectionViewDidHighlightCellAtIndexPath: function (collectionView, indexPath, args) {},
+
+	/**
+	 * Invoked by a collection view after highlighting a cell that it is not visible on screen to determine
+	 * if it should scroll to reveal that cell.
+	 * 
+	 * When this method is not implemented, the default behaviour is to scroll to off-screen cells that are highlighted.
+	 * @param collectionView 		The calling collection view.
+	 * @param indexPath 			The index path that was just highlighted.
+	 */
+	collectionViewShouldScrollToHighlightedCellAtIndexPath: function (collectionView, indexPath) {},
+
+	/**
 	 * Invoked by the collection view before running the initial presentation animation. Delegate objects can implement this method
 	 * to customize the animation's parameters.
 	 * @param collectionView <BMCollectionView>		The calling collection view.

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -18,7 +18,7 @@ const BM_AUTOMATIC_CELL_SIZE_MESSAGES = NO;
 /**
  * Constants representing the types of supplementary views that table layouts support.
  */
-export var BMCollectionViewTableLayoutSupplementaryView = Object.freeze({
+export var BMCollectionViewTableLayoutSupplementaryView = Object.freeze({ // <enum>
 	/**
 	 * Indicates that this supplementary view is a footer.
 	 */
@@ -1279,38 +1279,38 @@ BMExtend(BMCollectionViewTreeLayout.prototype, BMCollectionViewLayout.prototype,
 /**
  * Controls how cells are distributed within their row.
  */
-export var BMCollectionViewFlowLayoutGravity = Object.freeze({
+export var BMCollectionViewFlowLayoutGravity = Object.freeze({ // <enum>
 	
 	/**
 	 * The cells will flow to the center of the row with no spacing between them.
 	 */
-	Center: {},
+	Center: {}, // <enum>
 	
 	/**
 	 * The cells will be aligned to the start of the row.
 	 */
-	Start: {},
+	Start: {}, // <enum>
 	
 	/**
 	 * The cells will be aligned to the end of the row.
 	 */
-	End: {},
+	End: {}, // <enum>
 	
 	/**
 	 * The cells will flow to the edges of the row with equal spacing between them.
 	 */
-	Edge: {},
+	Edge: {}, // <enum>
 	
 	/**
 	 * The cells will flow such that they have equal spacing between them and the row edges.
 	 */
-	Spaced: {},
+	Spaced: {}, // <enum>
 	
 	/**
 	 * The cells will flow such that they will have no spacing between them.
 	 * If the cells in a row do not occupy the entire horizontal alrea of that row, they will be expanded proportionally until they do.
 	 */
-	Expand: {}
+	Expand: {} // <enum>
 	
 });
 
@@ -1325,39 +1325,39 @@ export var BMCollectionViewFlowLayoutAlignment = (function () {
 	/**
 	 * Controls how cells will be aligned within their row.
 	 */
-	var BMCollectionViewFlowLayoutAlignment = Object.freeze({
+	var BMCollectionViewFlowLayoutAlignment = Object.freeze({ // <enum>
 		
 		/**
 		 * @deprecated Use `Start`
 		 * The cells will be aligned to the starting edge of the row.
 		 */
-		Top: start,
+		Top: start, // <enum>
 		
 		/**
 		 * The cells will be aligned to the start of the row.
 		 */
-		Start: start,
+		Start: start, // <enum>
 		
 		/**
 		 * The cells will be aligned to the center of the row.
 		 */
-		Center: {},
+		Center: {}, // <enum>
 		
 		/**
 		 * @deprecated Use `End`
 		 * The cells will be aligned to the end of the row.
 		 */
-		Bottom: end,
+		Bottom: end, // <enum>
 		
 		/**
 		 * The cells will be aligned to the end of the row.
 		 */
-		End: end,
+		End: end, // <enum>
 		
 		/**
 		 * The cells will expand to fit the entire height of the row.
 		 */
-		Expand: {}
+		Expand: {} // <enum>
 		
 	});
 
@@ -1371,18 +1371,18 @@ export var BMCollectionViewFlowLayoutAlignment = (function () {
 /**
  * An enum containing the possible orientations that the flow layout can use.
  */
-export var BMCollectionViewFlowLayoutOrientation = Object.freeze({
+export var BMCollectionViewFlowLayoutOrientation = Object.freeze({ // <enum>
 	/**
 	 * Indicates that the flow layout will arrange cells primarily along the horizontal axis.
 	 * When the orientation is set to this value the flow layout will scroll horizontally.
 	 */
-	Horizontal: {},
+	Horizontal: {}, // <enum>
 
 	/**
 	 * Indicates that the flow layout will arrange cells primarily along the vertical axis.
 	 * When the orientation is set to this value the tile flow will scroll vertically.
 	 */
-	Vertical: {}
+	Vertical: {} // <enum>
 });
 
 // @endtype

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -4563,7 +4563,7 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 
 		let previousRow;
 
-		if (cellRow >= 0) {
+		if (cellRow > 0) {
 			previousRow = cellRow - 1;
 		}
 		else {

--- a/src/BMCollectionView/BMCollectionViewLayout.js
+++ b/src/BMCollectionView/BMCollectionViewLayout.js
@@ -295,7 +295,11 @@ BMCollectionViewLayout.prototype = {
 		const targetSection = toIndexPath.section;
 
 		for (let j = indexPath.section; j < targetSection; j++) {
-			const rowCount = this.collectionView.numberOfRowsInSectionAtIndex(j);
+			let rowCount = this.collectionView.numberOfRowsInSectionAtIndex(j);
+			if (j == toIndexPath.section) {
+				rowCount = toIndexPath.row + 1;
+			}
+
 			for (; i < rowCount; i++) {
 				indexPaths.push(this.collectionView.indexPathForObjectAtRow(i, {inSectionAtIndex: j}));
 			}

--- a/src/BMCollectionView/BMCollectionViewLayout.js
+++ b/src/BMCollectionView/BMCollectionViewLayout.js
@@ -158,7 +158,7 @@ BMCollectionViewLayout.prototype = {
 	/**
 	 * Invoked by the collection view to obtain the first index path in the layout.
 	 * The default implementation returns the first index path in the data set.
-	 * @returns <BMIndexPath | undefined>		The first index path, or `undefined` if no index path exists.
+	 * @returns <BMIndexPath, nullable>		The first index path, or `undefined` if no index path exists.
 	 */
 	firstIndexPath() {
 		const sectionCount = this.collectionView.numberOfSections();
@@ -177,6 +177,8 @@ BMCollectionViewLayout.prototype = {
 	 * If the given index path is at the left edge of the content area, the same index path should be returned.
 	 * 
 	 * The default implementation returns the previous index path in the data set.
+	 * @param indexPath <BMIndexPath>		The starting index path.
+	 * @returns <BMIndexPath>				The index path to the left of the starting index path.
 	 */
 	indexPathToTheLeftOfIndexPath(indexPath) {
 		if (indexPath.row > 0) {
@@ -206,6 +208,8 @@ BMCollectionViewLayout.prototype = {
 	 * If the given index path is at the top edge of the content area, the same index path should be returned.
 	 * 
 	 * The default implementation returns the result of calling `indexPathToTheLeftOfIndexPath`.
+	 * @param indexPath <BMIndexPath>		The starting index path.
+	 * @returns <BMIndexPath>				The index path above the starting index path.
 	 */
 	indexPathAboveIndexPath(indexPath) {
 		return this.indexPathToTheLeftOfIndexPath(indexPath);
@@ -218,6 +222,8 @@ BMCollectionViewLayout.prototype = {
 	 * If the given index path is at the right edge of the content area, the same index path should be returned.
 	 * 
 	 * The default implementation returns the next index path in the data set.
+	 * @param indexPath <BMIndexPath>		The starting index path.
+	 * @returns <BMIndexPath>				The index path to the right of the starting index path.
 	 */
 	indexPathToTheRightOfIndexPath(indexPath) {
 		const rowCount = this.collectionView.numberOfObjectsInSectionAtIndex(indexPath.section);
@@ -243,15 +249,49 @@ BMCollectionViewLayout.prototype = {
 	},
 
 	/**
-	 * Invoked by the collection to obtain the index path that is visually below the given index path.
+	 * Invoked by the collection view to obtain the index path that is visually below the given index path.
 	 * 
 	 * Subclasses may override this method to return an appropriate index path.
 	 * If the given index path is at the bottom edge of the content area, the same index path should be returned.
 	 * 
 	 * The default implementation returns the result of calling `indexPathToTheRightOfIndexPath`.
+	 * @param indexPath <BMIndexPath>		The starting index path.
+	 * @returns <BMIndexPath>				The index path below the starting index path.
 	 */
 	indexPathBelowIndexPath(indexPath) {
 		return this.indexPathToTheRightOfIndexPath(indexPath);
+	},
+
+	/**
+	 * Invoked by the collection view to obtain a list of index paths that are visually between
+	 * the two given index paths.
+	 * 
+	 * The default implementation returns a list containing the index paths from the data set that
+	 * start at the given index path, stopping at the target index path.
+	 * 
+	 * The starting and ending index paths should be included in the result.
+	 * @param indexPath <BMIndexPath>		The starting index path.
+	 * {
+	 * 	@param toIndexPath <BMIndexPath>	The ending index path.
+	 * }
+	 * @return <[BMIndexPath]>				An array of index paths.
+	 */
+	indexPathsFromIndexPath(indexPath, {toIndexPath}) {
+		const indexPaths = [];
+
+		let i = indexPath.row;
+		const targetSection = toIndexPath.section;
+
+		for (let j = indexPath.section; j < targetSection; j++) {
+			const rowCount = this.collectionView.numberOfRowsInSectionAtIndex(j);
+			for (; i < rowCount; i++) {
+				indexPaths.push(this.collectionView.indexPathForObjectAtRow(i, {inSectionAtIndex: j}));
+			}
+
+			i = 0;
+		}
+
+		return indexPaths;
 	},
 
     /****************************************** UPDATES ***********************************************/

--- a/src/BMCollectionView/BMCollectionViewLayout.js
+++ b/src/BMCollectionView/BMCollectionViewLayout.js
@@ -294,9 +294,9 @@ BMCollectionViewLayout.prototype = {
 		let i = indexPath.row;
 		const targetSection = toIndexPath.section;
 
-		for (let j = indexPath.section; j < targetSection; j++) {
-			let rowCount = this.collectionView.numberOfRowsInSectionAtIndex(j);
-			if (j == toIndexPath.section) {
+		for (let j = indexPath.section; j < targetSection + 1; j++) {
+			let rowCount = this.collectionView.numberOfObjectsInSectionAtIndex(j);
+			if (j == targetSection) {
 				rowCount = toIndexPath.row + 1;
 			}
 

--- a/src/BMCollectionView/BMCollectionViewLayout.js
+++ b/src/BMCollectionView/BMCollectionViewLayout.js
@@ -279,6 +279,18 @@ BMCollectionViewLayout.prototype = {
 	indexPathsFromIndexPath(indexPath, {toIndexPath}) {
 		const indexPaths = [];
 
+		// Swap the index paths if the target index path is before the source index path
+		if (toIndexPath.section < indexPath.section) {
+			const swapIndexPath = toIndexPath;
+			toIndexPath = indexPath;
+			indexPath = swapIndexPath;
+		}
+		else if (indexPath.section == toIndexPath.section && toIndexPath.row < indexPath.row) {
+			const swapIndexPath = toIndexPath;
+			toIndexPath = indexPath;
+			indexPath = swapIndexPath;
+		}
+
 		let i = indexPath.row;
 		const targetSection = toIndexPath.section;
 

--- a/src/BMCollectionView/BMCollectionViewLayout.js
+++ b/src/BMCollectionView/BMCollectionViewLayout.js
@@ -152,6 +152,108 @@ BMCollectionViewLayout.prototype = {
 		this._copy = undefined;
 	},
 
+
+	/************************************* CELL HIGHLIGHTING ********************************/
+
+	/**
+	 * Invoked by the collection view to obtain the first index path in the layout.
+	 * The default implementation returns the first index path in the data set.
+	 * @returns <BMIndexPath | undefined>		The first index path, or `undefined` if no index path exists.
+	 */
+	firstIndexPath() {
+		const sectionCount = this.collectionView.numberOfSections();
+
+		for (let i = 0; i < sectionCount; i++) {
+			const rowCount = this.collectionView.numberOfObjectsInSectionAtIndex(i);
+
+			if (rowCount) return this.collectionView.indexPathForObjectAtRow(0, {inSectionAtIndex: i});
+		}
+	},
+
+	/**
+	 * Invoked by the collection to obtain the index path that is visually to the left of the given index path.
+	 * 
+	 * Subclasses may override this method to return an appropriate index path.
+	 * If the given index path is at the left edge of the content area, the same index path should be returned.
+	 * 
+	 * The default implementation returns the previous index path in the data set.
+	 */
+	indexPathToTheLeftOfIndexPath(indexPath) {
+		if (indexPath.row > 0) {
+			return this.collectionView.indexPathForObjectAtRow(indexPath.row - 1, {inSectionAtIndex: indexPath.section});
+		}
+
+		if (indexPath.section > 0) {
+			let previousSection = indexPath.section - 1;
+			do {
+				const rowCount = this.collectionView.numberOfObjectsInSectionAtIndex(previousSection);
+				if (rowCount) {
+					return this.collectionView.indexPathForObjectAtRow(rowCount - 1, {inSectionAtIndex: previousSection});
+				}
+				else {
+					previousSection = previousSection - 1;
+				}
+			} while (previousSection >= 0);
+		}
+
+		return indexPath;
+	},
+
+	/**
+	 * Invoked by the collection to obtain the index path that is visually on top of the given index path.
+	 * 
+	 * Subclasses may override this method to return an appropriate index path.
+	 * If the given index path is at the top edge of the content area, the same index path should be returned.
+	 * 
+	 * The default implementation returns the result of calling `indexPathToTheLeftOfIndexPath`.
+	 */
+	indexPathAboveIndexPath(indexPath) {
+		return this.indexPathToTheLeftOfIndexPath(indexPath);
+	},
+
+	/**
+	 * Invoked by the collection to obtain the index path that is visually to the right of the given index path.
+	 * 
+	 * Subclasses may override this method to return an appropriate index path.
+	 * If the given index path is at the right edge of the content area, the same index path should be returned.
+	 * 
+	 * The default implementation returns the next index path in the data set.
+	 */
+	indexPathToTheRightOfIndexPath(indexPath) {
+		const rowCount = this.collectionView.numberOfObjectsInSectionAtIndex(indexPath.section);
+		if (indexPath.row < rowCount - 1) {
+			return this.collectionView.indexPathForObjectAtRow(indexPath.row + 1, {inSectionAtIndex: indexPath.section});
+		}
+
+		const sectionCount = this.collectionView.numberOfSections();
+		if (indexPath.section < sectionCount - 1) {
+			let nextSection = indexPath.section + 1;
+			do {
+				const rowCount = this.collectionView.numberOfObjectsInSectionAtIndex(nextSection);
+				if (rowCount) {
+					return this.collectionView.indexPathForObjectAtRow(0, {inSectionAtIndex: nextSection});
+				}
+				else {
+					nextSection = nextSection + 1;
+				}
+			} while (nextSection < sectionCount);
+		}
+
+		return indexPath;
+	},
+
+	/**
+	 * Invoked by the collection to obtain the index path that is visually below the given index path.
+	 * 
+	 * Subclasses may override this method to return an appropriate index path.
+	 * If the given index path is at the bottom edge of the content area, the same index path should be returned.
+	 * 
+	 * The default implementation returns the result of calling `indexPathToTheRightOfIndexPath`.
+	 */
+	indexPathBelowIndexPath(indexPath) {
+		return this.indexPathToTheRightOfIndexPath(indexPath);
+	},
+
     /****************************************** UPDATES ***********************************************/
 
     /**

--- a/src/BMCollectionView/BMCollectionViewTileLayout.js
+++ b/src/BMCollectionView/BMCollectionViewTileLayout.js
@@ -6,7 +6,7 @@ import {BMPointMakeWithX} from '../Core/BMPoint'
 import {BMSizeMake} from '../Core/BMSize'
 import {BMRectMake, BMRectMakeWithX, BMRectMakeWithOrigin} from '../Core/BMRect'
 import {BMIndexPathMakeWithIndexes} from '../Core/BMIndexPath'
-import {BMCollectionViewLayoutAttributesMakeForCellAtIndexPath, BMCollectionViewLayoutAttributesMakeForSupplementaryViewWithIdentifier} from './BMCollectionViewLayoutAttributes'
+import {BMCollectionViewLayoutAttributesMakeForCellAtIndexPath, BMCollectionViewLayoutAttributesMakeForSupplementaryViewWithIdentifier, BMCollectionViewLayoutAttributesType} from './BMCollectionViewLayoutAttributes'
 import {BMCollectionViewFlowLayoutSupplementaryView, BMCollectionViewTableLayoutSupplementaryView} from './BMCollectionViewFlowLayout'
 import {BMCollectionViewLayout} from './BMCollectionViewLayout'
 
@@ -1106,7 +1106,152 @@ BMCollectionViewTileLayout.prototype = BMExtend({}, BMCollectionViewLayout.proto
 
 		// Control shouldn't reach this point
 		debugger;
-	}
+	},
+
+	/************************************* CELL HIGHLIGHTING ********************************/
+
+	// @override - BMCollectionViewLayout
+	 indexPathToTheLeftOfIndexPath(indexPath) {
+		// Create a rect starting at the left edge of the given index path and request attributes in it
+		const startingAttributes = this.attributesForCellAtIndexPath(indexPath);
+
+		const extent = BMRectMake(
+			startingAttributes.frame.origin.x - this.collectionView.bounds.size.width - 1,
+			startingAttributes.frame.origin.y,
+			this.collectionView.bounds.size.width,
+			startingAttributes.frame.size.height
+		);
+
+		// Filter to only include cell attributes
+		const attributes = this.attributesForElementsInRect(extent).filter(a => a.itemType == BMCollectionViewLayoutAttributesType.Cell);
+
+		// return the rightmost attributes, if any
+		let maxAttributesX = extent.left;
+		let maxAttributesIndex = -1;
+
+		for (let i = 0; i < attributes.length; i++) {
+			if (attributes[i].frame.origin.x > maxAttributesX) {
+				maxAttributesX = attributes[i].frame.origin.x;
+				maxAttributesIndex = i;
+			}
+		}
+
+		if (maxAttributesIndex != -1) {
+			return attributes[maxAttributesIndex].indexPath;
+		}
+
+		return indexPath;
+	},
+
+	// @override - BMCollectionViewLayout
+	indexPathAboveIndexPath(indexPath) {
+		// Create a rect starting at the top edge of the given index path and request attributes in it
+		const startingAttributes = this.attributesForCellAtIndexPath(indexPath);
+
+		const extent = BMRectMake(
+			startingAttributes.frame.origin.x,
+			startingAttributes.frame.origin.y - this.collectionView.bounds.size.height - 1,
+			startingAttributes.frame.size.width,
+			this.collectionView.bounds.size.height
+		);
+
+		// Filter to only include cell attributes
+		const attributes = this.attributesForElementsInRect(extent).filter(a => a.itemType == BMCollectionViewLayoutAttributesType.Cell);
+
+		// return the bottommost attributes, if any
+		let maxAttributesY = extent.origin.y;
+		let maxAttributesIndex = -1;
+
+		for (let i = 0; i < attributes.length; i++) {
+			if (attributes[i].frame.origin.y > maxAttributesY) {
+				maxAttributesY = attributes[i].frame.origin.y;
+				maxAttributesIndex = i;
+			}
+		}
+
+		if (maxAttributesIndex != -1) {
+			return attributes[maxAttributesIndex].indexPath;
+		}
+
+		return indexPath;
+	},
+	
+	// @override - BMCollectionViewLayout
+	indexPathToTheRightOfIndexPath(indexPath) {
+		// Create a rect starting at the right edge of the given index path and request attributes in it
+		const startingAttributes = this.attributesForCellAtIndexPath(indexPath);
+
+		const extent = BMRectMake(
+			startingAttributes.frame.right + 1,
+			startingAttributes.frame.origin.y,
+			this.collectionView.bounds.size.width,
+			startingAttributes.frame.size.height
+		);
+
+		// Filter to only include cell attributes
+		const attributes = this.attributesForElementsInRect(extent).filter(a => a.itemType == BMCollectionViewLayoutAttributesType.Cell);
+
+		// return the leftmost attributes, if any
+		let minAttributesX = extent.right;
+		let minAttributesIndex = -1;
+
+		for (let i = 0; i < attributes.length; i++) {
+			if (attributes[i].frame.origin.x < minAttributesX) {
+				minAttributesX = attributes[i].frame.origin.x;
+				minAttributesIndex = i;
+			}
+		}
+
+		if (minAttributesIndex != -1) {
+			return attributes[minAttributesIndex].indexPath;
+		}
+
+		return indexPath;
+	},
+	
+	// @override - BMCollectionViewLayout
+	indexPathBelowIndexPath(indexPath) {
+		// Create a rect starting at the bottom edge of the given index path and request attributes in it
+		const startingAttributes = this.attributesForCellAtIndexPath(indexPath);
+
+		const extent = BMRectMake(
+			startingAttributes.frame.origin.x,
+			startingAttributes.frame.bottom + 1,
+			startingAttributes.frame.size.width,
+			this.collectionView.bounds.size.height
+		);
+
+		// Filter to only include cell attributes
+		const attributes = this.attributesForElementsInRect(extent).filter(a => a.itemType == BMCollectionViewLayoutAttributesType.Cell);
+
+		// return the topmost attributes, if any
+		let minAttributesY = extent.bottom;
+		let minAttributesIndex = -1;
+
+		for (let i = 0; i < attributes.length; i++) {
+			if (attributes[i].frame.origin.y < minAttributesY) {
+				minAttributesY = attributes[i].frame.origin.y;
+				minAttributesIndex = i;
+			}
+		}
+
+		if (minAttributesIndex != -1) {
+			return attributes[minAttributesIndex].indexPath;
+		}
+
+		return indexPath;
+	},
+	
+	// @override - BMCollectionViewLayout
+	indexPathsFromIndexPath(indexPath, {toIndexPath}) {
+		// Create and return the index paths available in the union of the two index paths' frames.
+		const startingAttributes = this.attributesForCellAtIndexPath(indexPath);
+		const targetAttributes = this.attributesForCellAtIndexPath(toIndexPath);
+
+		const attributes = this.attributesForElementsInRect(startingAttributes.frame.rectByUnionWithRect(targetAttributes.frame));
+		
+		return attributes.filter(a => a.itemType == BMCollectionViewLayoutAttributesType.Cell).map(a => a.indexPath);
+	},
 
 });
 

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -387,7 +387,7 @@
 }
 
 /* BMWindowSublabel should be used together with BMWindowLabel */
-.BMWindowSublabel {
+.BMWindowSublabel, .BMSublabel {
 	font-size: 14px;
 	color: rgba(0, 0, 0, .33);
 }
@@ -397,7 +397,7 @@
 		color: rgba(255, 255, 255, .9);
 	}
 	
-	.BMWindowSublabel, .BMLabel {
+	.BMWindowSublabel, .BMSubLabel {
 		color: rgba(255, 255, 255, .5);
 	}
 }

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -643,7 +643,7 @@
 	border: none;
 }
 
-.BMWindowButton:active, .BMButton:actie {
+.BMWindowButton:active, .BMButton:active {
 	background: rgb(0, 108, 235);
 }
 

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -1188,7 +1188,7 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 
 	border-radius: 8px !important;
 	box-shadow: 0px 4px 8px rgba(0, 0, 0, .1), 0px 0px 1px 1px rgba(0, 0, 0, .1);
-	z-index: 999999 !important;
+	z-index: 9999999 !important;
 	overflow: hidden !important;
 }
 
@@ -1259,14 +1259,41 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	margin-right: 16px;
 }
 
-.BMLayoutEditorConstraintPopupOption:hover, .BMMenuItem:hover, .BMMenuTouch > .BMMenuItem:active {
+@keyframes BMMenuItemActiveAnimation {
+	from {
+		background: transparent;
+		color: rgba(0, 0, 0, .8);
+	}
+
+	49% {
+		background: transparent;
+		color: rgba(0, 0, 0, .8);
+	}
+
+	50% {
+		background: rgb(0, 128, 255);
+		color: white;
+	}
+
+	to {
+		background: rgb(0, 128, 255);
+		color: white;
+	}
+}
+
+.BMLayoutEditorConstraintPopupOption:hover, .BMMenuTouch > .BMMenuItem:active, .BMMenuItem.BMMenuItemHighlighted {
 	background: rgb(0, 128, 255);
 	color: white;
 }
 
-.BMLayoutEditorConstraintPopupOption:active, .BMMenuItem:active, .BMMenuTouch > .BMMenuItem:hover {
+.BMLayoutEditorConstraintPopupOption:active, .BMMenuTouch > .BMMenuItem:hover {
 	background: transparent;
 	color: rgba(0, 0, 0, .8);
+}
+
+.BMMenuItem.BMMenuItemActive {
+	animation: .2s linear BMMenuItemActiveAnimation;
+	animation-fill-mode: both;
 }
 
 .BMLayoutEditorConstraintPopupOptionHighlighted, .BMMenuItemHighlighted {

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -1222,8 +1222,8 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 }
 
 .BMLayoutEditorConstraintPopupOption, .BMMenuItem {
-	height: 24px;
-	line-height: 24px;
+	height: 28px;
+	line-height: 28px;
 	vertical-align: middle;
 
 	padding-left: 16px;
@@ -2633,7 +2633,6 @@ The background layer contains the background.
 
 .BMLayoutEditorConstantSuggestions, .BMTextFieldSuggestions {
 	pointer-events: all;
-	max-height: 420px;
 	overflow: hidden;
 }
 

--- a/src/BMView/BMMenu.js
+++ b/src/BMView/BMMenu.js
@@ -1,10 +1,12 @@
 // @ts-check
 
-import {YES, NO, BMCopyProperties} from '../Core/BMCoreUI'
+import {YES, NO, BMCopyProperties, BMNumberByConstrainingNumberToBounds} from '../Core/BMCoreUI'
 import {BMPoint, BMPointMake} from '../Core/BMPoint'
 import {BMHook, __BMVelocityAnimate} from '../Core/BMAnimationContext'
 import 'velocity-animate'
 import { BMRectMakeWithNodeFrame } from '../Core/BMRect';
+import { BMView } from './BMView_v2.5';
+import { BMKeyboardShortcut } from '../BMWindow/BMKeyboardShortcut';
 
 /**
  * The standard spacing between the menu and the node it is created from.
@@ -219,6 +221,35 @@ BMMenu.prototype = {
     _sourceNodeDisplacement: undefined, // <Number, nullable>
 
     /**
+     * The index of the currently highlighted menu item.
+     */
+    _highlightedIndex: -1, // <Number>
+
+    get highlightedIndex() {
+        return this._highlightedIndex;
+    },
+
+    set highlightedIndex(index) {
+        if (index != this._highlightedIndex) {
+            this._highlightedIndex = index;
+
+            if (this._node) {
+                // Remove the currently highlighted item's style
+                const highlightedItem = this._node.querySelector('.BMMenuItemHighlighted');
+                if (highlightedItem) {
+                    highlightedItem.classList.remove('BMMenuItemHighlighted');
+                }
+
+                // And add it to the newly highlighted item
+                const nextHighlightedItem = this._node.children[index];
+                if (nextHighlightedItem) {
+                    nextHighlightedItem.classList.add('BMMenuItemHighlighted');
+                }
+            }
+        }
+    },
+
+    /**
      * Initializes this menu with the specified items.
      * The menu will be hidden by default; the method showAtPoint(_) should be used to make the menu visible.
      * 
@@ -241,6 +272,31 @@ BMMenu.prototype = {
         menuNode.className = this._CSSClass ? `BMMenu ${this._CSSClass}` : 'BMMenu';
         this._node = menuNode;
 
+        this._highlightedIndex = -1;
+
+        menuNode.tabIndex = -1;
+
+        // Register the keyboard shortcuts to be used while the menu is visible
+        const upArrow = BMKeyboardShortcut.keyboardShortcutWithKeyCode('ArrowUp', {modifiers: [], target: this, action: 'arrowUpPressedWithEvent'});
+        upArrow.preventsDefault = YES;
+        BMView.registerKeyboardShortcut(upArrow, {forNode: menuNode});
+
+        const downArrow = BMKeyboardShortcut.keyboardShortcutWithKeyCode('ArrowDown', {modifiers: [], target: this, action: 'arrowDownPressedWithEvent'});
+        downArrow.preventsDefault = YES;
+        BMView.registerKeyboardShortcut(downArrow, {forNode: menuNode});
+
+        const returnShortcut = BMKeyboardShortcut.keyboardShortcutWithKeyCode('Enter', {modifiers: [], target: this, action: 'returnPressedWithEvent'});
+        returnShortcut.preventsDefault = YES;
+        BMView.registerKeyboardShortcut(returnShortcut, {forNode: menuNode});
+
+        const spacebar = BMKeyboardShortcut.keyboardShortcutWithKeyCode('Space', {modifiers: [], target: this, action: 'returnPressedWithEvent'});
+        spacebar.preventsDefault = YES;
+        BMView.registerKeyboardShortcut(spacebar, {forNode: menuNode});
+
+        const tab = BMKeyboardShortcut.keyboardShortcutWithKeyCode('Tab', {modifiers: [], target: this, action: 'tabPressedWithEvent'});
+        tab.preventsDefault = YES;
+        BMView.registerKeyboardShortcut(tab, {forNode: menuNode});
+
         // The overlay which intercepts clicks outside of the menu
         const menuContainer = document.createElement('div');
         menuContainer.className = 'BMMenuContainer';
@@ -253,6 +309,10 @@ BMMenu.prototype = {
         this._renderMenuItems();
 
         menuNode.addEventListener('click', event => event.preventDefault());
+
+        menuNode.addEventListener('mouseleave', event => {
+            this.highlightedIndex = -1;
+        });
 
         menuContainer.addEventListener('click', event => {
             this.closeAnimated(YES);
@@ -271,12 +331,13 @@ BMMenu.prototype = {
     _renderMenuItems() {
         // Create and append the items for this menu
         const iconSize = this._iconSize;
-        for (const item of this._items) {
+
+        this._items.forEach((item, index) => {
             if (item.name.startsWith('---')) {
                 const itemNode = document.createElement('div');
                 itemNode.className = 'BMMenuDivider';
                 this._node.appendChild(itemNode);
-                continue;
+                return;
             }
 
             let itemNode = document.createElement('div');
@@ -298,6 +359,8 @@ BMMenu.prototype = {
             itemNode.appendChild(itemText);
     
             itemNode.addEventListener('click', event => {
+                itemNode.classList.add('BMMenuItemActive');
+
                 if (item.action) item.action(item);
 
                 if (this.delegate && this.delegate.menuDidSelectItem) {
@@ -305,8 +368,14 @@ BMMenu.prototype = {
                 }
             });
 
+            itemNode.addEventListener('mouseenter', event => {
+                this.highlightedIndex = index;
+            })
+
+            itemNode.addEventListener
+
             this._node.appendChild(itemNode);
-        }
+        });
     },
 
     /**
@@ -408,6 +477,8 @@ BMMenu.prototype = {
             delay += 16;
         }
 
+        menuNode.focus();
+
         // Animate the source node shadow
         await __BMVelocityAnimate(this._sourceNodeShadow, {translateY: displacement + 'px'}, {duration: duration, easing: easing});
 
@@ -484,6 +555,8 @@ BMMenu.prototype = {
             delay += 16;
         }
 
+        menuNode.focus();
+
         return menuNode;
     },
 
@@ -503,7 +576,7 @@ BMMenu.prototype = {
         this._node.style.pointerEvents = 'none'; 
         this._containerNode.style.pointerEvents = 'none';
         let delay = this._node.childNodes.length * 16 + 100 - 200;
-        delay = (delay < 0 ? 0 : delay);
+        delay = (delay < 0 ? 0 : delay) + 200;
 
         const sourceNodeShadow = this._sourceNodeShadow;
         const containerNode = this._containerNode;
@@ -517,8 +590,8 @@ BMMenu.prototype = {
         const easing = sourceNodeShadow ? 'easeInOutQuad' : 'easeInQuad';
 
         if (sourceNodeShadow) {
-            __BMVelocityAnimate(sourceNodeShadow, {translateY: '0px'}, {duration: duration, easing: easing});
-            __BMVelocityAnimate(containerNode, {opacity: 0}, {duration: duration, easing: easing});
+            __BMVelocityAnimate(sourceNodeShadow, {translateY: '0px'}, {duration: duration, easing: easing, delay});
+            __BMVelocityAnimate(containerNode, {opacity: 0}, {duration: duration, easing: easing, delay});
         }
 
         __BMVelocityAnimate(this._node, {
@@ -543,7 +616,7 @@ BMMenu.prototype = {
             }
         });
 
-        delay = 0;
+        delay = 200;
         for (let i = this._node.childNodes.length - 1; i >= 0; i--) {
             let child = this._node.childNodes[i];
             __BMVelocityAnimate(child, {translateY: '16px', translateZ: 0, opacity: 0}, {
@@ -556,7 +629,56 @@ BMMenu.prototype = {
 
         this._node = undefined;
         this._containerNode = undefined;
+    },
+
+    /**
+     * Invoked when the up arrow is pressed.
+     * @param event <KeyboardEvent>     The event that triggered this action.
+     */
+    arrowUpPressedWithEvent(event) {
+        if (this._highlightedIndex != 0) {
+            this.highlightedIndex = BMNumberByConstrainingNumberToBounds(this._highlightedIndex - 1, 0, this._items.length - 1);
+        }
+    },
+
+    /**
+     * Invoked when the down arrow is pressed.
+     * @param event <KeyboardEvent>     The event that triggered this action.
+     */
+    arrowDownPressedWithEvent(event) {
+        if (this._highlightedIndex != this._items.length - 1) {
+            this.highlightedIndex = BMNumberByConstrainingNumberToBounds(this._highlightedIndex + 1, 0, this._items.length - 1);
+        }
+    },
+
+    returnPressedWithEvent(event) {
+        if (this._highlightedIndex >= 0 && this._highlightedIndex < this._items.length - 1) {
+            const item = this._items[this._highlightedIndex];
+
+            if (item.action) item.action(item);
+
+            if (this.delegate && this.delegate.menuDidSelectItem) {
+                this.delegate.menuDidSelectItem(this, item);
+            }
+
+            const highlightedNode = this._node.querySelector('.BMMenuItemHighlighted');
+            if (highlightedNode) {
+                highlightedNode.classList.add('BMMenuItemActive');
+            }
+
+            this.closeAnimated(YES);
+        }
+    },
+
+    /**
+     * Invoked when the tab key is pressed.
+     * @param event <KeyboardEvent>     The event that triggered this action.
+     */
+    tabPressedWithEvent(event) {
+        // No action, this just prevents the keyboard focus from moving to another element
     }
+
+
 };
 
 /**

--- a/src/BMView/BMMenu.js
+++ b/src/BMView/BMMenu.js
@@ -225,6 +225,11 @@ BMMenu.prototype = {
      */
     _highlightedIndex: -1, // <Number>
 
+    /**
+     * The DOM node that was focused when this alert was opened.
+     */
+    _previouslyActiveNode: undefined, // DOMNode
+
     get highlightedIndex() {
         return this._highlightedIndex;
     },
@@ -296,6 +301,10 @@ BMMenu.prototype = {
         const tab = BMKeyboardShortcut.keyboardShortcutWithKeyCode('Tab', {modifiers: [], target: this, action: 'tabPressedWithEvent'});
         tab.preventsDefault = YES;
         BMView.registerKeyboardShortcut(tab, {forNode: menuNode});
+
+        const escape = BMKeyboardShortcut.keyboardShortcutWithKeyCode('Escape', {modifiers: [], target: this, action: 'escapePressedWithEvent'});
+        escape.preventsDefault = YES;
+        BMView.registerKeyboardShortcut(escape, {forNode: menuNode});
 
         // The overlay which intercepts clicks outside of the menu
         const menuContainer = document.createElement('div');
@@ -477,6 +486,7 @@ BMMenu.prototype = {
             delay += 16;
         }
 
+        this._previouslyActiveNode = document.activeElement;
         menuNode.focus();
 
         // Animate the source node shadow
@@ -555,6 +565,7 @@ BMMenu.prototype = {
             delay += 16;
         }
 
+        this._previouslyActiveNode = document.activeElement;
         menuNode.focus();
 
         return menuNode;
@@ -571,6 +582,10 @@ BMMenu.prototype = {
 
         if (this.delegate && this.delegate.menuWillClose) {
             this.delegate.menuWillClose(this);
+        }
+
+        if (this._previouslyActiveNode) {
+            this._previouslyActiveNode.focus();
         }
 
         this._node.style.pointerEvents = 'none'; 
@@ -676,6 +691,16 @@ BMMenu.prototype = {
      */
     tabPressedWithEvent(event) {
         // No action, this just prevents the keyboard focus from moving to another element
+    },
+
+    /**
+     * Invoked when the escape key is pressed.
+     * @param event <KeyboardEvent>     The event that triggered this action.
+     */
+    escapePressedWithEvent(event) {
+        if (this._node) {
+            this.closeAnimated(YES);
+        }
     }
 
 

--- a/src/BMView/BMTextField.js
+++ b/src/BMView/BMTextField.js
@@ -287,7 +287,7 @@ BMTextField.prototype = BMExtend(Object.create(BMView.prototype), {
             filteredSuggestions = suggestions.filter(e => e.toLowerCase().startsWith(inputNode.value.toLowerCase()));
 
             // Limit to the topmost 10 items
-            filteredSuggestions.length = Math.min(filteredSuggestions.length, 10);
+            filteredSuggestions.length = Math.min(filteredSuggestions.length, this.maxSuggestions);
             
             // Empty the menu
             if (menu) menu.innerHTML = '';

--- a/src/BMView/BMTextField.js
+++ b/src/BMView/BMTextField.js
@@ -212,7 +212,7 @@ BMTextField.prototype = BMExtend(Object.create(BMView.prototype), {
                     highlightedItemIndex = Math.max((highlightedItemIndex || 0) - 1, 0);
                 }
                 else {
-                    highlightedItemIndex = Math.min((isNaN(highlightedItemIndex) ? -1 : highlightedItemIndex) + 1, filteredSuggestions.length - 1);
+                    highlightedItemIndex = Math.min((isNaN(highlightedItemIndex) ? -1 : highlightedItemIndex) + 1, filteredSuggestions.length - 1, this.maxSuggestions - 1);
                 }
 
                 // Move the menu highlight

--- a/src/BMView/BMView_v2.5.js
+++ b/src/BMView/BMView_v2.5.js
@@ -910,16 +910,19 @@ BMView.prototype = BMExtend(BMView.prototype, {
 
     /**
      * The layout queue on which this view processes its layout passes.
-     * If this property is modified while this view had already registered a layout pass with a different queue,
-     * that layout pass will still run on that queue the next time it is drained.
      */
     _layoutQueue: _BMViewLayoutQueue, // <BMViewLayoutQueue, nullResettable>
     get layoutQueue() {
         return this._layoutQueue;
     },
     set layoutQueue(queue) {
+        const hasView = this._layoutQueue._views.has(this);
         this._layoutQueue._removeView(this);
         this._layoutQueue = queue || _BMViewLayoutQueue;
+
+        if (hasView) {
+            this._layoutQueue._enqueueView(this);
+        }
     },
 
     // #endregion

--- a/src/BMView/BMView_v2.5.js
+++ b/src/BMView/BMView_v2.5.js
@@ -674,6 +674,9 @@ export function BMView() {} // <constructor>
 	/**
 	 * Unregisters a keyboard shortcut. If this keyboard shortcut had not been previously registered, this method does nothing.
 	 * @param shortcut <BMKeyboardShortcut>			The keyboard shortcut to unregister.
+     * {
+     *  @param forNode <DOMNode>                    The DOM node for which the shortcut should be unregistered.
+     * }
 	 */
     BMView.unregisterKeyboardShortcut = function (shortcut, {forNode: node}) {
         const viewStub = _NodeKeyboardShortcutsMap.get(node);

--- a/src/BMView/BMView_v2.5.js
+++ b/src/BMView/BMView_v2.5.js
@@ -619,9 +619,7 @@ export function BMView() {} // <constructor>
     // keyboard shortcuts
     const _NodeKeyboardShortcutsMap = new WeakMap; // <WeakMap<DOMNode, Object>
 
-    /**
-     * A class that is a subset of `BMView` and contains only the keyboard shortcuts related functionality.
-     */
+    // A class that is a subset of `BMView` and contains only the keyboard shortcuts related functionality.
     const _BMViewKeyboardShortcutsStub = function (node) {
         this.node = node;
         this._keyboardShortcuts = {};
@@ -638,11 +636,11 @@ export function BMView() {} // <constructor>
         },
         
         unregisterKeyboardShortcut(shortcut) {
-            return BMView.prototype.registerKeyboardShortcut.apply(this, arguments);
+            return BMView.prototype.unregisterKeyboardShortcut.apply(this, arguments);
         },
         
         keyPressedWithEvent(event) {
-            return BMView.prototype.registerKeyboardShortcut.apply(this, arguments);
+            return BMView.prototype.keyPressedWithEvent.apply(this, arguments);
         },
         
         _keyboardShortcutsEnabled: NO,
@@ -2253,10 +2251,10 @@ BMView.prototype = BMExtend(BMView.prototype, {
 	 * @param event <KeyboardEvent>			The event that triggered this action.
 	 */
 	keyPressedWithEvent(event) {
-        if (!this._keyboardShortcuts[event.key]) return;
+        if (!this._keyboardShortcuts[event.code]) return;
 
 		// Check if a shortcut key has been pressed.
-		for (const shortcut of this._keyboardShortcuts[event.key]) {
+		for (const shortcut of this._keyboardShortcuts[event.code]) {
 			// Build the modifier bitmap for this event
 			let bitmap = 0;
 			for (const modifier in BMKeyboardShortcutModifier) {

--- a/src/BMView/BMView_v2.5.js
+++ b/src/BMView/BMView_v2.5.js
@@ -2271,7 +2271,7 @@ BMView.prototype = BMExtend(BMView.prototype, {
 
 			if (bitmap == shortcut._modifierBitmap) {
 				if (shortcut.preventsDefault) event.preventDefault();
-				shortcut.target[shortcut.action](event);
+				shortcut.target[shortcut.action](event, {forKeyboardShortcut: shortcut});
 			}
 		}
 	},

--- a/src/BMWindow/BMConfirmationPopup.js
+++ b/src/BMWindow/BMConfirmationPopup.js
@@ -180,6 +180,11 @@ BMAlertPopup.prototype = BMExtend(Object.create(BMWindow.prototype), {
     },
 
     /**
+     * The DOM node that was focused when this alert was opened.
+     */
+    _previouslyActiveNode: undefined, // DOMNode
+
+    /**
      * Designated initializer. Initializes this alert popup with the given labels.
      * @param title <String>                    The popup's title.
      * {
@@ -249,6 +254,8 @@ BMAlertPopup.prototype = BMExtend(Object.create(BMWindow.prototype), {
         escapeKeyboardShortcut.preventsDefault = YES;
         this.registerKeyboardShortcut(escapeKeyboardShortcut);
 
+        this._previouslyActiveNode = document.activeElement;
+
         return this;
     },
     /**
@@ -289,6 +296,10 @@ BMAlertPopup.prototype = BMExtend(Object.create(BMWindow.prototype), {
         if (this._result == BMConfirmationPopupResult.Undecided) {
             this._result = BMConfirmationPopupResult.Confirmed;
             this._resolve(BMConfirmationPopupResult.Confirmed);
+        }
+
+        if (this._previouslyActiveNode) {
+            this._previouslyActiveNode.focus();
         }
 
         return BMWindow.prototype.dismissAnimated.apply(this, arguments);
@@ -453,6 +464,10 @@ BMConfirmationPopup.prototype = BMExtend(Object.create(BMAlertPopup.prototype), 
         if (this._result == BMConfirmationPopupResult.Undecided) {
             this._result = BMConfirmationPopupResult.Cancelled;
             this._resolve(BMConfirmationPopupResult.Cancelled);
+        }
+
+        if (this._previouslyActiveNode) {
+            this._previouslyActiveNode.focus();
         }
 
         return BMWindow.prototype.dismissAnimated.apply(this, arguments);

--- a/src/BMWindow/BMKeyboardShortcut.js
+++ b/src/BMWindow/BMKeyboardShortcut.js
@@ -1,6 +1,6 @@
-import { NO } from "../Core/BMCoreUI";
-
 // @ts-check
+
+import { NO } from "../Core/BMCoreUI";
 
 // @type BMKeyboardShortcutModifier
 
@@ -101,7 +101,7 @@ BMKeyboardShortcut.prototype = {
     preventsDefault: NO, // <Boolean>
 
     /**
-     * Initializes this keyboard shortcut with the given key and optional modifiers, as well as
+     * Designated initializer. Initializes this keyboard shortcut with the given key and optional modifiers, as well as
      * the target and action that will handle it.
      * 
      * In order to be triggered, this keyboard shortcut must be registered with an event handler such as a window
@@ -129,6 +129,88 @@ BMKeyboardShortcut.prototype = {
         }
 
         return this;
+    },
+
+    /**
+     * Initializes this keyboard shortcut with the given keyboard event. If the event includes the control or command keys, these may be converted
+     * into a system key modifier based on the current platform.
+     * @param event <KeyboardEvent>                                     The keyboard event from which this keyboard shortcut should be initialized.
+     * {
+     * 	@param target <AnyObject>										The object that will handle this keyboard shortcut action.
+     * 	@param action <String>											The name of a method on the target object that will be invoked when this 
+     * 																	keyboard shortcut is triggered. That method will receive the keyboard event as its single parameter.
+     *  @param preventsDefault <Boolean, nullable>                      Defaults to `NO`. When set to `YES`, the default action of the event that triggers this keyboard shortcut will be prevented.
+     * }
+     * 
+     */
+    initWithKeyboardEvent(event, {target, action, preventsDefault} = {}) {
+        const modifiers = [];
+        if (event.shiftKey) {
+            modifiers.push(BMKeyboardShortcutModifier.Shift);
+        }
+        if (event.altKey) {
+            modifiers.push(BMKeyboardShortcutModifier.Option);
+        }
+        if (event.metaKey) {
+            if (BMKeyboardShortcutModifier.System.value == BMKeyboardShortcutModifier.Command.value) {
+                modifiers.push(BMKeyboardShortcutModifier.System);
+            }
+            else {
+                modifiers.push(BMKeyboardShortcutModifier.Command);
+            }
+        }
+        if (event.controlKey) {
+            if (BMKeyboardShortcutModifier.System.value == BMKeyboardShortcutModifier.Control.value) {
+                modifiers.push(BMKeyboardShortcutModifier.System);
+            }
+            else {
+                modifiers.push(BMKeyboardShortcutModifier.Control);
+            }
+        }
+
+        return this.initWithKeyCode(event.code, {modifiers, target, action, preventsDefault});
+    },
+
+    /**
+     * Initializes this keyboard shortcut with the given serialized object representation. A callback is used to
+     * convert from the target object ID to an actual target object.
+     * @param shortcut <Object>                 A serialized keyboard shortcut.
+     * {
+     *  @param targetID <Object ^(String)>      A callback that is invoked with the target ID and should return
+     *                                          the target object which will handle the keyboard shortcut.
+     * }
+     * @returns <Object>                        This keyboard shortcut.
+     */
+    initWithSerializedKeyboardShortcut(shortcut, {targetID: resolver}) {
+        if (shortcut._class != 'BMKeyboardShortcut') {
+            throw new Error(`Unknown keyboard shortcut class - "${shortcut._class}"`);
+        }
+
+        const target = resolver(shortcut._targetID);
+
+        const modifiers = shortcut._modifiers.map(modifier => {
+            return Object.values(BMKeyboardShortcutModifier).find(m => m.key == modifier)
+        });
+
+        return this.initWithKeyCode(shortcut._key, {modifiers, target, action: shortcut._action, preventsDefault: shortcut._preventsDefault});
+    },
+
+    /**
+     * Returns an object representation of this keyboard shortcut that can be used with `JSON.stringify` to 
+     * serialize this keyboard shortcut.
+     * @param ID <String>           A string that identifies the target object and can be used when recreating
+     *                              the keyboard shortcut instance.
+     * @returns <Object>            An object that can be used with `JSON.stringify`.
+     */
+    serializedKeyboardShortcutWithTargetID(ID) {
+        return {
+            _class: `BMKeyboardShortcut`,
+            _key: this._key,
+            _modifiers: this._modifiers.map(m => m.key),
+            _targetID: ID,
+            _action: this._action,
+            _preventsDefault: this.preventsDefault,
+        };
     }
 
 };
@@ -146,11 +228,43 @@ BMKeyboardShortcut.prototype = {
  * 	@param target <AnyObject>										The object that will handle this keyboard shortcut action.
  * 	@param action <String>											The name of a method on the target object that will be invoked when this 
  * 																	keyboard shortcut is triggered. That method will receive the keyboard event as its single parameter.
+ *  @param preventsDefault <Boolean, nullable>                      Defaults to `NO`. When set to `YES`, the default action of the event that triggers this keyboard shortcut will be prevented.
  * }
  * @return <BMKeyboardShortcut>                                     A keyboard shortcut.
  */
 BMKeyboardShortcut.keyboardShortcutWithKeyCode = function (key, args) {
     return (new BMKeyboardShortcut).initWithKeyCode(key, args);
+};
+
+
+/**
+ * Constructs and returns a keyboard shortcut with the given keyboard event. If the event includes the control or command keys, these may be converted
+ * into a system key modifier based on the current platform.
+ * @param event <KeyboardEvent>                                     The keyboard event from which this keyboard shortcut should be initialized.
+ * {
+ * 	@param target <AnyObject>										The object that will handle this keyboard shortcut action.
+ * 	@param action <String>											The name of a method on the target object that will be invoked when this 
+ * 																	keyboard shortcut is triggered. That method will receive the keyboard event as its single parameter.
+ *  @param preventsDefault <Boolean, nullable>                      Defaults to `NO`. When set to `YES`, the default action of the event that triggers this keyboard shortcut will be prevented.
+ * }
+ * 
+ */
+BMKeyboardShortcut.keyboardShortcutWithKeyboardEvent = function (event, args) {
+    return (new BMKeyboardShortcut).initWithKeyboardEvent(event, args);
+};
+
+/**
+ * Constructs and returns keyboard shortcut with the given serialized object representation. A callback is used to
+ * convert from the target object ID to an actual target object.
+ * @param shortcut <Object>                 A serialized keyboard shortcut.
+ * {
+ *  @param targetID <Object ^(String)>      A callback that is invoked with the target ID and should return
+ *                                          the target object which will handle the keyboard shortcut.
+ * }
+ * @returns <Object>                        A keyboard shortcut.
+ */
+BMKeyboardShortcut.keyboardShortcutWithSerializedKeyboardShortcut = function (shortcut, args) {
+    return (new BMKeyboardShortcut).initWithSerializedKeyboardShortcut(shortcut, args);
 };
 
 // @endtype

--- a/src/BMWindow/BMKeyboardShortcut.js
+++ b/src/BMWindow/BMKeyboardShortcut.js
@@ -9,22 +9,27 @@ import { NO } from "../Core/BMCoreUI";
  * for views and windows.
  */
 export const BMKeyboardShortcutModifier = Object.freeze({ // <enum>
+
 	/**
 	 * Represents the command key on macOS and iOS, windows key on Windows and meta key on Linux.
 	 */
 	Command: {key: 'metaKey', value: 1}, // <enum>
+
 	/**
 	 * Represents the option key on macOS and alt on other systems.
 	 */
 	Option: {key: 'altKey', value: 2}, // <enum>
+
 	/**
 	 * Represents the shit key.
 	 */
 	Shift: {key: 'shiftKey', value: 4}, // <enum>
+
 	/**
 	 * Represents the control key.
 	 */
 	Control: {key: 'ctrlKey', value: 8}, // <enum>
+
 	/**
 	 * Represents the command key on macOS and iOS and control key on other systems.
 	 */

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -8,6 +8,7 @@ import {BMView} from '../BMView/BMView_v2.5'
 import {BMLayoutOrientation} from '../BMView/BMLayoutSizeClass'
 import { BMSizeMake } from '../Core/BMSize'
 import { BMLayoutAttribute } from '../BMView/BMLayoutConstraint_v2.5'
+import { BMViewport } from '../BMView/BMViewport'
 
 //@ts-check
 // @type BMWindowOverlay extends BMView

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -1254,6 +1254,10 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 				completionHandler = () => {
 					this.anchorRect = undefined;
 					this.anchorNode = undefined;
+
+					if (this._keyboardShortcutsEnabled) {
+						this.node.focus();
+					}
 				}
 			}
 
@@ -1261,6 +1265,10 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 
 			this._blocker.style.display = 'block';
 			this._window.style.display = 'block';
+
+			if (this._keyboardShortcutsEnabled) {
+				this.node.focus();
+			}
 
 			this._overlay._windowWillAppear();
 		
@@ -1277,14 +1285,14 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 
 			this._blocker.style.pointerEvents = '';
 			this._window.style.pointerEvents = '';
+
+			if (this._keyboardShortcutsEnabled) {
+				this.node.focus();
+			}
 			
 			if (self.delegate && self.delegate.windowDidAppear) self.delegate.windowDidAppear(self);
 			
 			if (args && args.completionHandler) args.completionHandler();
-		}
-
-		if (this._keyboardShortcutsEnabled) {
-			this.node.focus();
 		}
 	},
 	

--- a/src/Core/BMAnimationContext.js
+++ b/src/Core/BMAnimationContext.js
@@ -834,10 +834,6 @@ export function BMAnimationApplyBlocking(blocking) {
     }
 	animation.options.complete = completeCallback;
 	
-	if (window.event && window.event.shiftKey) {
-		animation.options.duration = animation.options.duration * 5;
-		window.event.preventDefault();
-	}
     
     var stride = animation.options.stride;
 	var delay = animation.options.delay || 0;

--- a/src/Core/BMCoreUI.js
+++ b/src/Core/BMCoreUI.js
@@ -392,6 +392,10 @@ export function BMUUIDMake() {
  */
 export var BMHTMLEntity = Object.freeze({ // <enum>
 	/**
+	 * The HTML entity representing the control key.
+	 */
+	Control: '&#8963;', // <enum>
+	/**
 	 * The HTML entity representing the bowen knot Command symbol.
 	 */
 	Command: '&#8984;', // <enum>
@@ -414,7 +418,11 @@ export var BMHTMLEntity = Object.freeze({ // <enum>
 	/**
 	 * The HTML entity representing the Return symbol.
 	 */
-	Return: '&#9166;' // <enum>
+	Return: '&#9166;', // <enum>
+	/**
+	 * The HTML entity representing the Escape symbol.
+	 */
+	Escape: '&#9099;', // <enum>
 });
 
 // @endtype


### PR DESCRIPTION
# 2.8

## Generic

Resolved a typo with the `BMButton` CSS class that prevented its active state rules from applying.

Added the `Control` and `Escape` properties to `BMHTMLEntity`.

## BMAnimationContext

Animations will no longer run in slow-motion when triggered from an event while the shift key was pressed.

## BMView

The methods for registering and managing keyboard shortcuts have moved from `BMWindow` to `BMView` so that any subclass can make use of this functionality. Improved performance when registering a large number of keyboard shortcuts.

Added two new static methods `registerKeyboardShortcut(_, {forNode})` and `unregisterKeyboardShortcut(_, {forNode})` that can be used to add keyboard shortcuts to elements without creating a view for them.

When setting the `layoutQueue` property, any pending layout pass will now occur on the new layout queue.

## BMMenu

While a menu is open, menu items can now be navigated using the keyboard up and down arrow keys and can be selected using the return or spacebar keys. Additionally it can be closed with the escape key.

## BMCollectionView

Added a new readonly `visibleBounds` property that returns a rect describing the part of the bounds that are visible on screen.

When using `scrollToSupplementaryViewWithIdentifier` or `scrollToCellAtIndexPath` and not specifying any gravity, the default values will now depend on the cell's position relative to the current bounds, rather that defaulting to top and left.

Resolved an issue in `scrollToSupplementaryViewWithIdentifier` where the default top gravity was set to an improper default value when omitted.

Resolved an issue when using nested collection views that all had drag & drop enabled which would cause multiple collection views to start their drag & drop operation at the same when initiating it from a cell in one of the nested collection views. Now, starting a drag & drop from one collection view will prevent any parent collection views from starting their own drag & drop.

Collection View will now ignore clicks originating on content editable elements, in addition to its previous exclusion list.

Added support for a new state for cells called highlighting and a series of new properties and method to support this. Cells are highlighted when they are clicked or by using the keyboard arrow keys. The following properties and methods related to this functionality have been added:
 - A new `highlightedIndexPath` property can be used to set or retrieve the currently highlighted index path.
 - A new `isCellAtIndexPathHighlighted(_)` method can be used to test if a given index path is highlighted.
 - A new `keyboardArrowPressed(_, {withEvent})` method is invoked when arrow keys are pressed on the keyboard and can be invoked to simulate an arrow press.
 - A new `configureKeyboardShortcuts` method is now invoked during initialization to enable cell highlighting via the keyboard. Subclasses may also override this method to add their own keyboard shortcuts. A similar `disableKeyboardShortcuts` method is invoked when keyboard navigation is disabled.
 - A new `supportsKeyboardNavigation` property, with a default value of `YES` can be used to control whether keyboard navigation is enabled or not.

When creating cells, collection view will now properly handle layout changes that occur in the cell's initializer.

## BMCollectionViewDelegate

Delegates can now implement the following methods to control and respond to cells being highlighted:
 - `collectionViewShouldHighlightCellForArrowKey(_, _, {withEvent})` can be used to control when keyboard events are processed.
 - `collectionViewCanHighlightCellAtIndexPath(_, _, {withEvent})` can be used to control whether specific cells may be highlighted or not.
 - `collectionViewDidHighlightCellAtIndexPath(_, _, {withEvent})` can be used to respond to cells being highlighted.
 - `collectionViewDidDehighlightCellAtIndexPath(_, _, {withEvent})` can be used to respond to cells being dehighlighted.
 - `collectionViewShouldScrollToHighlightedCellAtIndexPath(_, _)` is invoked when an off-screen cell is highlighted to determine whether the collection should scroll to reveal that cell.

Resolved an issue where several event arguments were declared as jQuery events when in fact they were standard events.

## BMCollectionViewLayout

The following new methods have been added and may be overriden by layout subclasses to improve keyboard navigation:
 - `firstIndexPath()` is used to obtain the first visible index path.
 - `indexPathToTheLeftOfIndexPath(_)` is used to obtain the index path that is visually to the left of a given index path.
 - `indexPathToTheRightOfIndexPath(_)` is used to obtain the index path that is visually to the right of a given index path.
 - `indexPathAboveIndexPath(_)` is used to obtain the index path that is visually above a given index path.
 - `indexPathBelowIndexPath(_)` is used to obtain the index path that is visually below a given index path.

A new `indexPathsFromIndexPath(_, {toIndexPath})` method can be used to obtain a list of index paths that are visually between two index paths.

The `BMCollectionViewFlowLayout`, `BMCollectionViewMasonryLayout` and `BMCollectionViewTileLayout` classes each provide their own specific implementation of those methods.

## BMCollectionViewFlowLayout

Resolves an issue with `BMCollectionViewFlowLayoutGravity`, `BMCollectionViewFlowLayoutAlignment` and `BMCollectionViewFlowLayoutOrientation` that had improper type definitions.

## BMKeyboardShortcut

This type is now properly included in the definitions file.

Added a new `serializedKeyboardShortcutWithTargetID(_)` method that can be used to obtain a plain object representing the keyboard shortcut that can be stringified. A new static `keyboardShortcutWithSerializedKeyboardShortcut(_, {targetID})` method and a new `initWithSerializedKeyboardShortcut(_, {targetID})` initializer can be used to obtain back a keyboard shortcut from a plain object representation.

Added a new `initWithKeyboardEvent(_, {target, action, preventsDefault})` initializer and a new `keyboardShortcutWithKeyboardEvent(_, {target, action, preventsDefault})` static method that can be used to obtain a keyboard shortcut from a keyboard event.

When keyboard shortcuts are triggered, the action method will now also receive a second parameter containing the triggered shortcut object. The signature of the method becomes `(_, {forKeyboardShortcut})`.

## BMAlertPopup

When dismissed, the element that was focused when the alert was shown will acquire focus again.

## BMTextField

Resolved various bugs with this class.

A new `maxSuggestions` property can be set to control how many entries appear in the autocomplete menu.