### PR TITLE
2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Fixed an issue that could cause drag & drop to occasionally fail when the drag status indicator was positioned below the mouse pointer.
 
+The default value for `supportsKeyboardNavigation` has been set to `NO` to avoid side effects when upgrading from older versions.
+
+Collection view will no longer acquire focus when its cells are clicked when keyboard navigation is disabled.
+
 ## BMCollectionViewFlowLayout
 
 Resolves an issue that caused keyboard navigation using the up/down arrows in vertical layout and left/right arrows in horizontal layouts to fail when using non-static cell sizes.
@@ -21,6 +25,10 @@ Resolves an issue that caused the active menu item's text to temporarily become 
 ## BMWindow
 
 Resolves an issue that caused the node referenced via the `anchorNode` property to remain permanently hidden if the window was dismissed while its appear animation was in progress.
+
+## BMViewLayoutEditor
+
+Resolves an issue that caused the "Deactivate Constraints" button to not work.
 
 # 2.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 2.8.3
 
+## BMCollectionView
+
+Fixed an issue that could cause drag & drop to occasionally fail when the drag status indicator was positioned below the mouse pointer.
+
 ## BMCollectionViewFlowLayout
 
 Resolves an issue that caused keyboard navigation using the up/down arrows in vertical layout and left/right arrows in horizontal layouts to fail when using non-static cell sizes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 2.8.3
+
+## BMCollectionViewFlowLayout
+
+Resolves an issue that caused keyboard navigation using the up/down arrows in vertical layout and left/right arrows in horizontal layouts to fail when using non-static cell sizes.
+
+Resolves an issue where using the `Expand` content gravity with a horizontal layout caused the size adjustments to be applied to the cell heights instead of their widths.
+
+Resolves an issue when using automatic cell sizes that could occur when the preliminary layout would fit in the collection view's frame after a first measurement but a scrollbar would be required after subsequent measurements.
+
+## BMMenu
+
+Resolves an issue that caused the last item in menus to not be selectable using the spacebar or return key.
+
+Resolves an issue that caused the active menu item's text to temporarily become dark and unreadable in dark mode when selected.
+
+## BMWindow
+
+Resolves an issue that caused the node referenced via the `anchorNode` property to remain permanently hidden if the window was dismissed while its appear animation was in progress.
+
 # 2.8.2
 
 ## BMMonacoCodeEditor

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-core-ui",
     "packageName": "BMCoreUI",
     "moduleName": "BMCoreUI",
-    "version": "2.8.2",
+    "version": "2.8.3",
     "description": "A collection of reusable UI classes.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -3988,7 +3988,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		if (options && options.withEvent) options.withEvent._BMOriginalTarget = cell.node;
 
         // Acquire focus if not already owned
-        if (document.activeElement != this.node) {
+        if (document.activeElement != this.node && this._supportsKeyboardNavigation) {
             this.node.focus();
         }
 
@@ -4053,7 +4053,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		if (options && options.withEvent) options.withEvent._BMOriginalTarget = cell.node;
 
         // Acquire focus if not already owned
-        if (document.activeElement != this.node) {
+        if (document.activeElement != this.node && this._supportsKeyboardNavigation) {
             this.node.focus();
         }
 
@@ -4075,7 +4075,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		if (options && options.withEvent) options.withEvent._BMOriginalTarget = cell.node;
 
         // Acquire focus if not already owned
-        if (document.activeElement != this.node) {
+        if (document.activeElement != this.node && this._supportsKeyboardNavigation) {
             this.node.focus();
         }
 		

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -693,7 +693,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	/**
 	 * Defaults to `YES`. When set to `NO`, keyboard navigation is disabled.
 	 */
-	_supportsKeyboardNavigation: YES, // <Boolean>
+	_supportsKeyboardNavigation: NO, // <Boolean>
 
 	get supportsKeyboardNavigation() {
 		return this._supportsKeyboardNavigation;

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -2716,8 +2716,10 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 					// by the cell width
 					numberOfColumns = (length / cellSize) | 0;
 				}
+
+				numberOfColumns = Math.max(numberOfColumns, 1);
 			}
-			cachedLayout.numberOfColumns = Math.max(numberOfColumns, 1);
+			cachedLayout.numberOfColumns = numberOfColumns;
 			
 			// Generate prototype rows for each column count up to the maximum
 			for (var i = 0; i < numberOfColumns; i++) {

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -1699,9 +1699,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 	 * When using automatic cell sizes, the generator will yield execution and only calculate portions of the layout on demand.
 	 * With the exeption of the first invocation, it is required to pass an index path to the iterator's `next` method. The layout process
 	 * will continue until it fully lays out the cell for that index path, at which point it will yield again.
-	 * @param useOffset <Boolean>			When set to `YES` the layout will take the scrollbar size into account.
+	 * @param useOffset <Boolean>							When set to `YES` the layout will take the scrollbar size into account.
+	 * {
+	 * 	@param targetRect <BMRect, nullable>				When computing a layout using automatic cell sizes, this is an optional rect up to which
+	 * 														to measure cells. This is reserved for when this is invoked as a delegate.
+	 * 	@param targetIndexPath <BMIndexPath, nullable>		When computing a layout using automatic cell sizes, this is an optional index path up to which
+	 * 														to measure cells. This is reserved for when this is invoked as a delegate.
+	 * }
 	 */
-	*_prepareLayoutWithScrollbarOffsetGenerator(useOffset) {
+	*_prepareLayoutWithScrollbarOffsetGenerator(useOffset, target) {
 		
 		// To standardize naming in order to support the orientation setting, the following terms are used:
 		// Length - refers to the dimension across the axis on which collection view scrolls: height for vertical and width for horizontal
@@ -1803,7 +1809,6 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 				targetRect?: BMRect;
 			}
 			*/
-			let target;
 
 			// The sections that contain the preliminary layout
 			const preliminarySections = [];
@@ -2069,7 +2074,12 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 
 					cachedLayout.size = BMSizeMake(this.collectionView.frame.size.width, height);
 	
-					target = yield;
+					// Yield after building the preliminary layout and wait for a target rect or index path up to which to measure
+					if (!target) {
+						// If a target is already supplied (as a parameter) this is a delegate generator and processing should continue
+						// until this target
+						target = yield;
+					}
 
 					// When requesting a rect initially, pre-measure the cells up to that rect
 					if (target.rect) {
@@ -2085,7 +2095,13 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 
 					cachedLayout.size = BMSizeMake(width, this.collectionView.frame.size.height);
 	
-					target = yield;
+					// Yield after building the preliminary layout and wait for a target rect or index path up to which to measure
+					if (!target) {
+						// If a target is already supplied (as a parameter) this is a delegate generator and processing should continue
+						// until this target
+						target = yield;
+					}
+
 					// When requesting a rect initially, pre-measure the cells up to that rect
 					if (target.rect) {
 						measureCellsInRect(target.rect);
@@ -2220,7 +2236,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 
 						// If the row height exceeds the collection view frame height, perform a second layout pass to account for the scrollbars
 						if (row[rowStartAttribute] + rowBreadth > frameSize) {
-							if (this.collectionView.scrollBarSize && !useOffset) return this._prepareLayoutWithScrollbarOffset(YES);
+							if (this.collectionView.scrollBarSize && !useOffset) {
+								if (target) {
+									// With automatic cell size delegate iteration to the new invocation
+									return yield *this._prepareLayoutWithScrollbarOffsetGenerator(YES, target);
+								}
+								else {
+									return this._prepareLayoutWithScrollbarOffset(YES);
+								}
+							}
 						}
 						
 						// if there is one
@@ -2383,7 +2407,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 						
 						// If the total height exceeds the collection view frame height, perform a second layout pass to account for the scrollbars
 						if (height > frameHeight) {
-							if (this.collectionView.scrollBarSize && !useOffset) return this._prepareLayoutWithScrollbarOffset(YES);
+							if (this.collectionView.scrollBarSize && !useOffset) {
+								if (target) {
+									// With automatic cell size delegate iteration to the new invocation
+									return yield *this._prepareLayoutWithScrollbarOffsetGenerator(YES, target);
+								}
+								else {
+									return this._prepareLayoutWithScrollbarOffset(YES);
+								}
+							}
 						}
 					}
 					else {
@@ -2404,7 +2436,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 						
 						// If the total height exceeds the collection view frame height, perform a second layout pass to account for the scrollbars
 						if (width > frameWidth) {
-							if (this.collectionView.scrollBarSize && !useOffset) return this._prepareLayoutWithScrollbarOffset(YES);
+							if (this.collectionView.scrollBarSize && !useOffset) {
+								if (target) {
+									// With automatic cell size delegate iteration to the new invocation
+									return yield *this._prepareLayoutWithScrollbarOffsetGenerator(YES, target);
+								}
+								else {
+									return this._prepareLayoutWithScrollbarOffset(YES);
+								}
+							}
 						}
 					}
 				}
@@ -2418,7 +2458,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 					
 					// If the total height exceeds the collection view frame height, perform a second layout pass to account for the scrollbars
 					if (height > frameHeight) {
-						if (this.collectionView.scrollBarSize && !useOffset) return this._prepareLayoutWithScrollbarOffset(YES);
+						if (this.collectionView.scrollBarSize && !useOffset) {
+							if (target) {
+								// With automatic cell size delegate iteration to the new invocation
+								return yield *this._prepareLayoutWithScrollbarOffsetGenerator(YES, target);
+							}
+							else {
+								return this._prepareLayoutWithScrollbarOffset(YES);
+							}
+						}
 					}
 				}
 				else {
@@ -2429,7 +2477,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 					
 					// If the total height exceeds the collection view frame height, perform a second layout pass to account for the scrollbars
 					if (width > frameWidth) {
-						if (this.collectionView.scrollBarSize && !useOffset) return this._prepareLayoutWithScrollbarOffset(YES);
+						if (this.collectionView.scrollBarSize && !useOffset) {
+							if (target) {
+								// With automatic cell size delegate iteration to the new invocation
+								return yield *this._prepareLayoutWithScrollbarOffsetGenerator(YES, target);
+							}
+							else {
+								return this._prepareLayoutWithScrollbarOffset(YES);
+							}
+						}
 					}
 				}
 				
@@ -2440,7 +2496,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 				
 				// If the total height exceeds the collection view frame height, perform a second layout pass to account for the scrollbars
 				if (height > frameHeight) {
-					if (this.collectionView.scrollBarSize && !useOffset) return this._prepareLayoutWithScrollbarOffset(YES);
+					if (this.collectionView.scrollBarSize && !useOffset) {
+						if (target) {
+							// With automatic cell size delegate iteration to the new invocation
+							return yield *this._prepareLayoutWithScrollbarOffsetGenerator(YES, target);
+						}
+						else {
+							return this._prepareLayoutWithScrollbarOffset(YES);
+						}
+					}
 				}
 			
 				// If the height is lower than the collection view's height, the content gravity must be applied to all cached attributes
@@ -2534,7 +2598,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 			else {
 				// If the total height exceeds the collection view frame height, perform a second layout pass to account for the scrollbars
 				if (width > frameWidth) {
-					if (this.collectionView.scrollBarSize && !useOffset) return this._prepareLayoutWithScrollbarOffset(YES);
+					if (this.collectionView.scrollBarSize && !useOffset) {
+						if (target) {
+							// With automatic cell size delegate iteration to the new invocation
+							return yield *this._prepareLayoutWithScrollbarOffsetGenerator(YES, target);
+						}
+						else {
+							return this._prepareLayoutWithScrollbarOffset(YES);
+						}
+					}
 				}
 			
 				// If the height is lower than the collection view's height, the content gravity must be applied to all cached attributes

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -1977,15 +1977,15 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 							
 							numberOfColumns++;
 						} while (usedLength < maximumLength && expectedSize);
-
-						// Ensure that there is at least one column
-						numberOfColumns = Math.max(numberOfColumns, 1);
 					}
 					else {
 						// If there is no minimum spacing required, then the number of columns is simply the available space divided
 						// by the cell width
-						numberOfColumns = Math.max((maximumLength / expectedSize) | 0, 1);
+						numberOfColumns = (maximumLength / expectedSize) | 0;
 					}
+
+					// Ensure that there is at least one column
+					numberOfColumns = Math.max(numberOfColumns, 1);
 				}
 
 				// Create the preliminary sections
@@ -2710,16 +2710,14 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 						
 						numberOfColumns++;
 					} while (usedLength < length && cellSize);
-
-					numberOfColumns = Math.max(numberOfColumns, 1);
 				}
 				else {
 					// If there is no minimum spacing required, then the number of columns is simply the available space divided
 					// by the cell width
-					numberOfColumns = Math.max((length / cellSize) | 0, 1);
+					numberOfColumns = (length / cellSize) | 0;
 				}
 			}
-			cachedLayout.numberOfColumns = numberOfColumns;
+			cachedLayout.numberOfColumns = Math.max(numberOfColumns, 1);
 			
 			// Generate prototype rows for each column count up to the maximum
 			for (var i = 0; i < numberOfColumns; i++) {
@@ -4489,19 +4487,22 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 		const row = indexPath.row;
 
 		// Find the row where the current index path is
-		const sectionRows = this.cachedLayout.sections[section];
+		const cachedSection = this.cachedLayout.sections[section];
 
-		if (!sectionRows) return indexPath;
+		if (!cachedSection) return indexPath;
+
+		const sectionRows = cachedSection.rows;
 		
 		let rowIndex = 0;
 		const rowCount = sectionRows.length;
 		for (rowIndex; rowIndex < rowCount; rowIndex++) {
-			if (row.startIndex <= row && row.endIndex >= row) {
+			const sectionRow = sectionRows[rowIndex];
+			if (sectionRow.startIndex <= row && sectionRow.endIndex >= row) {
 				break;
 			}
 		}
 
-		const attributes = sectionRows[rowIndex].attributes;
+		const attributes = sectionRows[rowIndex].attributes.find(a => a.indexPath.row == row);
 		const positionProperty = this._orientation == BMCollectionViewFlowLayoutOrientation.Vertical ? 'x' : 'y';
 		const position = attributes.frame.center[positionProperty];
 
@@ -4616,19 +4617,22 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 		const row = indexPath.row;
 
 		// Find the row where the current index path is
-		const sectionRows = this.cachedLayout.sections[section];
+		const cachedSection = this.cachedLayout.sections[section];
 
-		if (!sectionRows) return indexPath;
+		if (!cachedSection) return indexPath;
+
+		const sectionRows = cachedSection.rows;
 		
 		let rowIndex = 0;
 		const rowCount = sectionRows.length;
 		for (rowIndex; rowIndex < rowCount; rowIndex++) {
-			if (row.startIndex <= row && row.endIndex >= row) {
+			const sectionRow = sectionRows[rowIndex];
+			if (sectionRow.startIndex <= row && sectionRow.endIndex >= row) {
 				break;
 			}
 		}
 
-		const attributes = sectionRows[rowIndex].attributes;
+		const attributes = sectionRows[rowIndex].attributes.find(a => a.indexPath.row == row);
 		const positionProperty = this._orientation == BMCollectionViewFlowLayoutOrientation.Vertical ? 'x' : 'y';
 		const position = attributes.frame.center[positionProperty];
 

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -2607,7 +2607,7 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 								const scaledRowHeight = rowWidth * scaleFactor | 0;
 								for (const attribute of row.attributes) {
 									attribute.frame.origin.x += displacement;
-									attribute.frame.size.height = attribute.frame.size.height * scaleFactor | 0;
+									attribute.frame.size.width = attribute.frame.size.width * scaleFactor | 0;
 								}
 
 								// Advance the displacement based on the row's new width then displace the row end

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -1305,13 +1305,35 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 		color: rgba(255, 255, 255, .9);
 	}
 
-	.BMLayoutEditorConstraintPopupOption:active, .BMMenuItem:active, .BMMenuTouch > .BMMenuItem:hover {
+	.BMLayoutEditorConstraintPopupOption:active, .BMMenuTouch > .BMMenuItem:hover {
 		background: transparent;
 		color: white;
 	}
 
 	.BMMenuTouch > .BMMenuItem {
 		border-bottom-color: rgba(255, 255, 255, .1);
+	}
+
+	@keyframes BMMenuItemActiveAnimation {
+		from {
+			background: transparent;
+			color: rgba(255, 255, 255, .9);
+		}
+	
+		49% {
+			background: transparent;
+			color: rgba(255, 255, 255, .9);
+		}
+	
+		50% {
+			background: rgb(0, 128, 255);
+			color: white;
+		}
+	
+		to {
+			background: rgb(0, 128, 255);
+			color: white;
+		}
 	}
 }
 

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -32,6 +32,8 @@
 	position: fixed;
 
 	box-shadow: 0px 4px 12px rgba(0, 0, 0, .33);
+
+	pointer-events: none;
 }
 
 .BMDragIndicatorRed {

--- a/src/BMView/BMMenu.js
+++ b/src/BMView/BMMenu.js
@@ -667,7 +667,7 @@ BMMenu.prototype = {
     },
 
     returnPressedWithEvent(event) {
-        if (this._highlightedIndex >= 0 && this._highlightedIndex < this._items.length - 1) {
+        if (this._highlightedIndex >= 0 && this._highlightedIndex < this._items.length) {
             const item = this._items[this._highlightedIndex];
 
             if (item.action) item.action(item);

--- a/src/BMViewLayoutEditor/BMLayoutEditorSettingCells.js
+++ b/src/BMViewLayoutEditor/BMLayoutEditorSettingCells.js
@@ -518,10 +518,10 @@ BMLayoutEditorSettingsDeactivateConstraintsCell.prototype = BMExtend(Object.crea
 
         buttonView.node.addEventListener('click', event => {
             if (hasOption && hasShift && hasCtrl) {
-                new Set(this.setting.target.rootView.allConstraints).forEach(constraint => constraint.remove());
+                new Set(this.setting.target._view.rootView.allConstraints).forEach(constraint => constraint.remove());
             }
             else if (hasOption) {
-                for (let constraint of this.setting.target.localConstraints) {
+                for (let constraint of this.setting.target._view.localConstraints) {
                     if (hasShift) {
                         constraint.remove();
                     }

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -1166,7 +1166,7 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 									}
 									else {
 										node.style.display = nodeDisplay;
-										delete self._nodeDisplay;
+										self._nodeDisplay = undefined;
 									}
 
 									completionHandler();
@@ -1328,14 +1328,14 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 			// Create a copy of the given node which will be used in the animation in place of the original node
 			const node = this._anchorNode;
 			
-			if ('_nodeDisplay' in self) {
+			if (typeof self._nodeDisplay != 'undefined') {
 				node.style.display = self._nodeDisplay;
 			}
 			
 			const rect = BMRectMakeWithNodeFrame(node);
 			const animationNode = node.cloneNode(YES);
 			
-			const nodeDisplay = ('_nodeDisplay' in self) ? self._nodeDisplay : node.style.display;
+			const nodeDisplay = (typeof self._nodeDisplay != 'undefined') ? self._nodeDisplay : node.style.display;
 			self._nodeDisplay = undefined;
 			
 			animationNode.style.position = 'fixed';

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -1124,6 +1124,7 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 			const animationNode = node.cloneNode(YES);
 			
 			const nodeDisplay = node.style.display;
+			self._nodeDisplay = nodeDisplay;
 			
 			animationNode.style.position = 'fixed';
 			animationNode.style.zIndex = BM_WINDOW_Z_INDEX_MAX + 1;
@@ -1165,6 +1166,7 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 									}
 									else {
 										node.style.display = nodeDisplay;
+										delete self._nodeDisplay;
 									}
 
 									completionHandler();


### PR DESCRIPTION
## BMCollectionViewFlowLayout

Resolves an issue that caused keyboard navigation using the up/down arrows in vertical layout and left/right arrows in horizontal layouts to fail when using non-static cell sizes.

Resolves an issue where using the `Expand` content gravity with a horizontal layout caused the size adjustments to be applied to the cell heights instead of their widths.

Resolves an issue when using automatic cell sizes that could occur when the preliminary layout would fit in the collection view's frame after a first measurement but a scrollbar would be required after subsequent measurements.

## BMMenu

Resolves an issue that caused the last item in menus to not be selectable using the spacebar or return key.

Resolves an issue that caused the active menu item's text to temporarily become dark and unreadable in dark mode when selected.

## BMWindow

Resolves an issue that caused the node referenced via the `anchorNode` property to remain permanently hidden if the window was dismissed while its appear animation was in progress.