### PR TITLE
2.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 2.8.5
+
+## BMCollectionView
+
+Resolves an issue where calling `updateEntireDataAnimated` with the animated parameter set to `NO` would cause the completion handler to never be invoked.
+
+## BMCollectionViewLayout
+
+The `shouldInvalidateLayoutForBoundsChange` method now takes in an additional argument `fromBounds` which are the bounds prior to changing.
+
+## BMCollectionViewDelegate
+
+The `collectionViewBoundsDidChange` method now takes in an additional argument `fromBounds` which are the bounds prior to changing.
+
+## BMWindow
+
+Resolves an issue where `BMWindow` would call `windowDidResignKeyWindow` while still being the key window.
+
+A new `windowDidClose` method is invoked on windows after they closes. Subclasses can override this method to perform any cleanup necessary after being dismissed.
+
+Invoking the `release` method on a window that was already released will now have no effect.
+
+## BMAlertPopup
+
+This window will now reposition itself whenever the viewport is resized.
+
+Alert popups and any subclasses will now automatically `release` themselves after closing.
+
 # 2.8.3
 
 ## BMCollectionView

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ By default, if there is enough space in all directions, popovers will now appear
 
 A new initializer argument `submenu` makes it possible to specify a submenu that will be displayed when selecting menu items.
 
+A new `CSSClass` property can be specified on menu items to add it the item's node when its menu is active.
+
 ## BMMenu
 
 Menus can now be displayed as submenus when set as the `submenu` property of a menu item. On pointer based devices, a submenu opens when an item containing one becomes the highlighted item. On touch based devices, a submenu opens when an item containing one is selected.
@@ -61,6 +63,10 @@ Resolves an issue where the active animation for menu items did not play unless 
 Removes the delay when closing a menu without selecting any item. Additionally removes the delay when closing touch menus in all cases.
 
 The node from which a touch a menu opens will now be slightly scaled up while the menu is active. Additionally, when the node from which a touch menu is opened is too large to fit on the screen, it will now be scaled down.
+
+When there isn't sufficient space on the right for a touch menu to open under a node, the node will be moved towards the left to make space for it while the menu is active.
+
+When setting the `CSSClass` property while the menu is active, the new classes will now apply to the current menu element.
 
 # 2.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.8.5
+# 2.9
 
 ## BMCollectionView
 
@@ -47,6 +47,20 @@ Popovers can now appear to the left or to the right of their anchors, in additio
 Adds a new `permittedDirections` property that can be used to specify in which directions the popover's indicator may appear relative to the popover. Additionally, the popover will also take the specified order of the directions into account when deciding which direction to select when it can fit within multiple directions.
 
 By default, if there is enough space in all directions, popovers will now appear below their anchor rather than above.
+
+## BMMenuItem
+
+A new initializer argument `submenu` makes it possible to specify a submenu that will be displayed when selecting menu items.
+
+## BMMenu
+
+Menus can now be displayed as submenus when set as the `submenu` property of a menu item. On pointer based devices, a submenu opens when an item containing one becomes the highlighted item. On touch based devices, a submenu opens when an item containing one is selected.
+
+Resolves an issue where the active animation for menu items did not play unless the menu item had an action specified.
+
+Removes the delay when closing a menu without selecting any item. Additionally removes the delay when closing touch menus in all cases.
+
+The node from which a touch a menu opens will now be slightly scaled up while the menu is active. Additionally, when the node from which a touch menu is opened is too large to fit on the screen, it will now be scaled down.
 
 # 2.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Resolves an issue where calling `updateEntireDataAnimated` with the animated par
 
 When invoking `invalidateContentSize` during a data update, the content size will now be invalidated when the update finishes.
 
+Resolved an issue where calling `invalidateLayout` during a data update would cause collection view to permanently ignore future requests to invalidate the layout.
+
 ## BMCollectionViewLayout
 
 The `shouldInvalidateLayoutForBoundsChange` method now takes in an additional argument `fromBounds` which are the bounds prior to changing.
@@ -13,6 +15,10 @@ The `shouldInvalidateLayoutForBoundsChange` method now takes in an additional ar
 ## BMCollectionViewFlowLayout
 
 Resolves an issue where the content size was not properly invalidated in some cases when using automatic cell size.
+
+Resolves an issue where a data update could throw an error while using automatic cell size at certain sizes when using headers or footers.
+
+Resolves an issue where a data update could throw an error while using automatic cell size if an element that was previously offscreen became visible.
 
 ## BMCollectionViewDelegate
 
@@ -22,7 +28,7 @@ The `collectionViewBoundsDidChange` method now takes in an additional argument `
 
 Resolves an issue where `BMWindow` would call `windowDidResignKeyWindow` while still being the key window.
 
-A new `windowDidClose` method is invoked on windows after they closes. Subclasses can override this method to perform any cleanup necessary after being dismissed.
+A new `windowDidClose` method is invoked on windows after they close. Subclasses can override this method to perform any cleanup necessary after being dismissed.
 
 Invoking the `release` method on a window that was already released will now have no effect.
 
@@ -34,7 +40,7 @@ Alert popups and any subclasses will now automatically `release` themselves afte
 
 ## BMPopoverIndicatorDirection
 
-A new `BMPopoverIndicatorDirection` enum can be used to specify in the directions in which a popover's indicator may appear.
+A new `BMPopoverIndicatorDirection` enum can be used to specify the directions in which a popover's indicator may appear.
 
 ## BMPopover
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ When there isn't sufficient space on the right for a touch menu to open under a 
 
 When setting the `CSSClass` property while the menu is active, the new classes will now apply to the current menu element.
 
+Resolves an issue where it was possible to open a touch menu that was already open.
+
+Resolves an issue where using the keyboard to highlight menu items could highlight menu dividers.
+
+## BMMenuDelegate
+
+Resolves an issue where `menuWillOpen` was not invoked for touch menus.
+
+A new `menuShouldSelectItem` method can be implemented by delegate objects to control whether menu items can be selected.
+
+Added the type definitions for this object.
+
 # 2.8.3
 
 ## BMCollectionView

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 Resolves an issue where calling `updateEntireDataAnimated` with the animated parameter set to `NO` would cause the completion handler to never be invoked.
 
+When invoking `invalidateContentSize` during a data update, the content size will now be invalidated when the update finishes.
+
 ## BMCollectionViewLayout
 
 The `shouldInvalidateLayoutForBoundsChange` method now takes in an additional argument `fromBounds` which are the bounds prior to changing.
+
+## BMCollectionViewFlowLayout
+
+Resolves an issue where the content size was not properly invalidated in some cases when using automatic cell size.
 
 ## BMCollectionViewDelegate
 
@@ -25,6 +31,22 @@ Invoking the `release` method on a window that was already released will now hav
 This window will now reposition itself whenever the viewport is resized.
 
 Alert popups and any subclasses will now automatically `release` themselves after closing.
+
+## BMPopoverIndicatorDirection
+
+A new `BMPopoverIndicatorDirection` enum can be used to specify in the directions in which a popover's indicator may appear.
+
+## BMPopover
+
+Resolves an issue that caused the popover to appear below an anchor rect or anchor node even if there was no space for it, instead of appearing above it.
+
+Resolves an issue where the value of the `borderRadius` property was not taken into account.
+
+Popovers can now appear to the left or to the right of their anchors, in addition to above or below.
+
+Adds a new `permittedDirections` property that can be used to specify in which directions the popover's indicator may appear relative to the popover. Additionally, the popover will also take the specified order of the directions into account when deciding which direction to select when it can fit within multiple directions.
+
+By default, if there is enough space in all directions, popovers will now appear below their anchor rather than above.
 
 # 2.8.3
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -25,7 +25,10 @@ const removeFiles = [
     'BMCollectionView/BMCollectionViewDelegate.js',
     'BMCollectionView/BMCollectionViewDataSet.js',
     'BMWindow/BMWindowDelegate.js',
-    'BMView/BMLayoutVariableProvider.js',
+    'BMViewLayoutEditor/BMLayoutVariableProvider.js',
+    'BMView/BMMenuDelegate.js',
+    'BMViewLayoutEditor/BMLayoutEditorDelegate.js',
+    'BMViewLayoutEditor/BMLayoutEditorSettingsDelegate.js',
 
     // These files are in early development
     'BMScrollView.js',
@@ -109,6 +112,7 @@ const DTSFiles = [
     'BMViewLayoutEditor/BMLayoutEditorSettingsComplexCells.js', 
     'BMViewLayoutEditor/BMLayoutVariableProvider.js', 
     'BMView/BMMenu.js',
+    'BMView/BMMenuDelegate.js',
     'BMView/BMTextField.js',
     'BMView/BMTextFieldDelegate.js',
     'BMCollectionView/BMCollectionViewLayoutAttributes.js', 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -35,6 +35,7 @@ const removeFiles = [
     'Core/BMDragController.js',
     'BMScroller.js',
     'Core/BMInterpolator.js',
+    'BMViewLayoutEditor/CSS/BMCSSStyleRule.js',
 
     // These files were included for documentation and are not needed at runtimea
     'JSDoc.html',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-core-ui",
     "packageName": "BMCoreUI",
     "moduleName": "BMCoreUI",
-    "version": "2.8.5",
+    "version": "2.9.0",
     "description": "A collection of reusable UI classes.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-core-ui",
     "packageName": "BMCoreUI",
     "moduleName": "BMCoreUI",
-    "version": "2.8.3",
+    "version": "2.8.5",
     "description": "A collection of reusable UI classes.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -4,7 +4,7 @@ import {YES, NO, BMExtend, BMScrollBarGetSize, BMAddSmoothMousewheelInteractionT
 import {BMInset} from '../Core/BMInset'
 import {BMPointMake} from '../Core/BMPoint'
 import {BMSizeMake} from '../Core/BMSize'
-import {BMRect, BMRectMake, BMRectMakeWithNodeFrame, BMRectByInterpolatingRect} from '../Core/BMRect'
+import {BMRect, BMRectMake, BMRectMakeWithNodeFrame, BMRectMakeWithOrigin, BMRectByInterpolatingRect} from '../Core/BMRect'
 import {BMIndexPathNone} from '../Core/BMIndexPath'
 import {BMAnimateWithBlock, BMAnimationContextBeginStatic, BMAnimationContextGetCurrent, BMAnimationContextAddCompletionHandler, BMAnimationApply, __BMVelocityAnimate, BMHook} from '../Core/BMAnimationContext'
 import {BMView, BMViewLayoutQueue} from '../BMView/BMView_v2.5'
@@ -1451,6 +1451,8 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 			return;
 		}
 
+		const previousBounds = BMRectMakeWithOrigin(previousBoundsOffset, {size: this._bounds.size.copy()});
+
 		// Dequeue the layout queue after a minimal delay to minimize visual artifacts
 		(async () => {
 			await 0;
@@ -1459,19 +1461,21 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		
 		
 		// Invalidate the layout if the layout object requires invalidation when the bounds change
-		if (this._layout.shouldInvalidateLayoutForBoundsChange(this._bounds)) {
+		if (this._layout.shouldInvalidateLayoutForBoundsChange(this._bounds, {fromBounds: previousBounds})) {
 			this.invalidateLayoutForBoundsChange();
 		
 			// Let the delegate know that the bounds were updated
 			if (this.delegate && typeof this.delegate.collectionViewBoundsDidChange == 'function') {
-				this.delegate.collectionViewBoundsDidChange(this, this._bounds);
+				this.delegate.collectionViewBoundsDidChange(this, this._bounds, {fromBounds: previousBounds});
 			}
 			
 			// Let the layout know that the invalidation was successful.
 			this._layout.didInvalidateLayoutForBoundsChange();
 
 			// Prepare to request and apply the snapping offset from the layout
-			snapsScrollPosition && this._prepareForSnappingScrollOffsetWithPreviousOffset(previousBoundsOffset);
+			if (snapsScrollPosition) {
+				this._prepareForSnappingScrollOffsetWithPreviousOffset(previousBoundsOffset);
+			}
 
 			return;
 		}
@@ -1619,12 +1623,14 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		
 			// Let the delegate know that the bounds were updated
 			if (this.delegate && typeof this.delegate.collectionViewBoundsDidChange == 'function') {
-				this.delegate.collectionViewBoundsDidChange(this, this._bounds);
+				this.delegate.collectionViewBoundsDidChange(this, this._bounds, {fromBounds: previousBounds});
 			}
 		    
 
 			// Prepare to request and apply the snapping offset from the layout
-			snapsScrollPosition && this._prepareForSnappingScrollOffsetWithPreviousOffset(previousBoundsOffset);
+			if (snapsScrollPosition) {
+				this._prepareForSnappingScrollOffsetWithPreviousOffset(previousBoundsOffset);
+			}
 
 		    return;
 	    }
@@ -1644,13 +1650,15 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		
 		// Let the delegate know that the bounds were updated
 		if (this.delegate && typeof this.delegate.collectionViewBoundsDidChange == 'function') {
-			this.delegate.collectionViewBoundsDidChange(this, this._bounds);
+			this.delegate.collectionViewBoundsDidChange(this, this._bounds, {fromBounds: previousBounds});
 		}
 
 		// Prepare to request and apply the snapping offset from the layout, unless the collection view is performing an
 		// automated scrolling animation
 		if (!this._isPerformingAnimatedScrolling) {
-			snapsScrollPosition && this._prepareForSnappingScrollOffsetWithPreviousOffset(previousBoundsOffset);
+			if (snapsScrollPosition) {
+				this._prepareForSnappingScrollOffsetWithPreviousOffset(previousBoundsOffset);
+			}
 		}
 
 	    
@@ -5026,6 +5034,10 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 				else if (cell.itemType === BMCollectionViewLayoutAttributesType.SupplementaryView) {
 					if (this.dataSet.updateSupplementaryView) this.dataSet.updateSupplementaryView(cell, {withIdentifier: cell.reuseIdentifier, atIndexPath: cell.indexPath});
 				}
+			}
+			
+			if (options && options.completionHandler) {
+				options.completionHandler();
 			}
 			
 			this._executeDataCompletionCallbacks();

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -1185,8 +1185,13 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 	 * Should be invoked by layout objects when the content size changes, but no other aspect of the layout does.
 	 */
 	invalidateContentSize() {
-		// If an update is in progress, ignore this
-		if (!this._collectionEnabled) return;
+		// If an update is in progress, delay this until after the update
+		if (!this._collectionEnabled) {
+			this.registerDataCompletionCallback(() => {
+				this.invalidateContentSize();
+			})
+			return;
+		}
 
 	    var size = this._layout.contentSize();
 	    

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -1024,8 +1024,6 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 			this.__awaitsLayout = YES;
 			return;
 		}
-
-		this._blocksLayoutInvalidation = YES;
 	    
 	    // Do not invalidate the layout during an animated data update
 	    if (this.isUpdatingData) {
@@ -1033,6 +1031,8 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 		    this.registerDataCompletionCallback(function () { self.invalidateLayout(); });
 		    return;
 		}
+
+		this._blocksLayoutInvalidation = YES;
 		
 		// If the layout supports animated changes and an animation context is active, make this change animated
 		let animation;

--- a/src/BMCollectionView/BMCollectionViewDelegate.js
+++ b/src/BMCollectionView/BMCollectionViewDelegate.js
@@ -23,8 +23,11 @@ BMCollectionViewDelegate.prototype = {
 	 * Invoked by the collection view whenever the bounds change.
 	 * @param collectionView <BMCollectionView>		The calling collection view.
 	 * @param newBounds <BMRect>					The new bounds.
+	 * {
+	 * 	@param fromBounds <BMRect>					The previous bounds.
+	 * }
 	 */
-	collectionViewBoundsDidChange: function (collectionView, bounds) {},	
+	collectionViewBoundsDidChange: function (collectionView, bounds, {fromBounds}) {},	
 
 	/**
 	 * Invoked by the collection view whenever any cell will be rendered.

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -3335,10 +3335,18 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 		// for the requested index path
 		if (this._expectedCellSize) {
 			if (this.cachedLayout.resolvedIndexPath.section < indexPath.section ||
-				(this.cachedLayout.resolvedIndexPath.section == indexPath.section && this.cachedLayout.resolvedIndexPath.row < indexPath.row)) {
-					// If the layout has not been resolved up to this index path, continue computing it until it has
-					this._layoutIterator.next({indexPath: indexPath});
+				(this.cachedLayout.resolvedIndexPath.section == indexPath.section && this.cachedLayout.resolvedIndexPath.row < indexPath.row)
+			) {
+				const currentResolvedHeight = this.cachedLayout.resolvedHeight;
+
+				// If the layout has not been resolved up to this index path, continue computing it until it has
+				this._layoutIterator.next({indexPath: indexPath});
+
+				// If the resolved height changes, invalidate the content size
+				if (currentResolvedHeight != this.cachedLayout.resolvedHeight) {
+					this.invalidateContentSize();
 				}
+			}
 		}
 	    
 	    // Return the cached attributes when using dynamic sizes

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -4332,22 +4332,33 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 		var attributes;
 		var self = this;
 		
-		this.collectionView.usingOldDataSet(function () {
-			// When using automatic cell sizes, it is important to ensure that the sizing information has been computed
-			// for the requested index path
-			if (self._expectedCellSize) {
-				if (self.previousLayout.resolvedIndexPath.section < indexPath.section ||
-					(self.previousLayout.resolvedIndexPath.section == indexPath.section && self.previousLayout.resolvedIndexPath.row < indexPath.row)) {
+		// When using automatic cell sizes, it is important to ensure that the sizing information has been computed
+		// for the requested index path
+		if (self._expectedCellSize) {
+			if (self.previousLayout.resolvedIndexPath.section < indexPath.section ||
+				(self.previousLayout.resolvedIndexPath.section == indexPath.section && self.previousLayout.resolvedIndexPath.row < indexPath.row)) {
+					self.collectionView.usingOldDataSet(function () {
 						// If the layout has not been resolved up to this index path, continue computing it until it has
 						self.previousLayout.iterator.next({indexPath: indexPath});
-					}
-			}
+					});
+				}
+		}
+		
+		this.collectionView.usingOldDataSet(function () {
 
 			if (self._cellSize && !self._expectedCellSize) {
 				attributes = self.computedAttributesForCellAtIndexPath(indexPath, {usingCache: self.previousLayout});
 			}
 			else {
 				attributes = self.cachedAttributesForCellAtIndexPath(indexPath, {usingCache: self.previousLayout});
+
+				if (!attributes) {
+					// When using automatic cell sizes, it is possible that the attributes for the moving cell were not computed
+					// in this case, return a copy of the current attributes, with the opacity set to 0
+					attributes = options.withTargetAttributes.copy();
+
+					attributes.style = Object.assign(attributes.style, {opacity: 0});
+				}
 			}
 		});
 		
@@ -4358,6 +4369,21 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 	initialAttributesForMovingSupplementaryViewWithIdentifier: function (identifier, options) {
 		var attributes;
 		var self = this;
+
+		// When using automatic cell sizes, ensure that the sizing information has been computed for the requested index path
+		if (self._expectedCellSize) {
+			if (self.cachedLayout.resolvedIndexPath.section < options.atIndexPath.section ||
+				(self.cachedLayout.resolvedIndexPath.section == options.atIndexPath.section && identifier == BMCollectionViewFlowLayoutSupplementaryView.Footer)) {
+					if (options.atIndexPath.section == self.collectionView.numberOfSections() - 1) {
+						// If there is no following section, compute until the last index path
+						self._layoutIterator.next({indexPath: self.collectionView.indexPathForObjectAtRow(self.collectionView.numberOfObjectsInSectionAtIndex(options.atIndexPath.section) - 1, {inSectionAtIndex: options.atIndexPath.section})});
+					}
+					else {
+						// If the layout has not been resolved up to this index path, continue computing up to the beginning of the next section
+						self._layoutIterator.next({indexPath: self.collectionView.indexPathForObjectAtRow(0, {inSectionAtIndex: options.atIndexPath.section + 1})});
+					}
+			}
+		}
 		
 		this.collectionView.usingOldDataSet(function () {
 			if (identifier === BMCollectionViewTableLayoutSupplementaryView.Empty) {
@@ -4368,6 +4394,14 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
 			}
 			else {
 				attributes = self.cachedAttributesForSupplementaryViewWithIdentifier(identifier, {atIndexPath: options.atIndexPath, usingCache: self.previousLayout});
+
+				if (!attributes) {
+					// When using automatic cell sizes, it is possible that the attributes for the moving supplementary view were not computed
+					// in this case, return a copy of the current attributes, with the opacity set to 0
+					attributes = options.withTargetAttributes.copy();
+
+					attributes.style = Object.assign(attributes.style, {opacity: 0});
+				}
 			}
 		});
 		

--- a/src/BMCollectionView/BMCollectionViewLayout.js
+++ b/src/BMCollectionView/BMCollectionViewLayout.js
@@ -659,9 +659,12 @@ BMCollectionViewLayout.prototype = {
      * Layout objects should return YES from this method if the new bounds require a new layout.
      * The default implementation returns NO in all cases.
      * @param bounds <BMRect>       The new bounds.
+	 * {
+	 * 	@param fromBounds <BMRect>	The previous bounds.
+	 * }
      * @return <Boolean>            True if the new frame requires a new layout, false otherwise.
      */
-    shouldInvalidateLayoutForBoundsChange: function (bounds) {
+    shouldInvalidateLayoutForBoundsChange: function (bounds, {fromBounds}) {
         return NO;
     },
 

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -1120,7 +1120,8 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 }
 
 
-/* MARK: Layout editor popup */
+/* MARK: Menu and container, Layout editor popup */
+/* #region - Menu container */
 
 .BMLayoutEditorConstraintPopupContainer, .BMMenuContainer {
 	position: absolute;
@@ -1132,6 +1133,12 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 
 	/* Sadly needed for Thingworx environment */
 	z-index: 9999999;
+}
+
+/* A class that is temporarily added to the menu container to allow the user
+   to move over menu items without triggering them while moving torwards the submenu */
+.BMMenuContainer.BMMenuContainerSubmenuActive > * {
+	pointer-events: none !important;
 }
 
 .BMMenuContainerFullScreen {
@@ -1146,7 +1153,8 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	}
 }
 
-.BMLayoutEditorConstraintPopup, .BMMenu {
+.BMLayoutEditorConstraintPopup, 
+.BMMenu {
 	position: absolute;
 
 	display: flex;
@@ -1157,6 +1165,8 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 
 	background-color: rgba(255, 255, 255, .8);
 	box-shadow: 0px 4px 8px rgba(0, 0, 0, .1), 0px 0px 1px 1px rgba(0, 0, 0, .1);
+
+	color: rgba(0, 0, 0, .8);
 
 	border-radius: 8px;
 }
@@ -1192,10 +1202,39 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	box-shadow: 0px 4px 8px rgba(0, 0, 0, .1), 0px 0px 1px 1px rgba(0, 0, 0, .1);
 	z-index: 9999999 !important;
 	overflow: hidden !important;
+
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+
+	-webkit-tap-highlight-color: transparent;
 }
 
 .BMMenuSourceNode {
-	display: none !important;
+	visibility: hidden !important;
+}
+
+/* While a touch menu has a submenu, its menu items should not respond to events */
+.BMMenuTouchSubmenu.BMMenu > .BMMenuItem {
+	pointer-events: none;
+
+	/* Additionally add an opacity transition to the items to be used in an animation */
+	transition: opacity .2s ease;
+}
+
+.BMMenuTouchSubmenu.BMMenu {
+	transition: filter .2s ease;
+}
+
+.BMMenuTouchSubmenu.BMMenu.BMMenuInactive > * {
+	opacity: .75 !important;
+}
+
+.BMMenuTouchSubmenu.BMMenu.BMMenuInactive {
+	filter: brightness(95%);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1205,7 +1244,8 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 }
 
 @media (prefers-color-scheme: dark) {
-	.BMLayoutEditorConstraintPopup, .BMMenu {
+	.BMLayoutEditorConstraintPopup,
+	.BMMenu {
 		background-color: rgba(50, 50, 50, .75);
 		box-shadow: 0px 4px 8px rgba(0, 0, 0, .66), 0px 0px 0px 1px rgba(0, 0, 0, .66);
 	}
@@ -1223,13 +1263,16 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	}
 }
 
+/* #endregion */
+
+/* #region - Menu item */
+
 .BMLayoutEditorConstraintPopupOption, .BMMenuItem {
 	height: 28px;
 	line-height: 28px;
 	vertical-align: middle;
 
 	padding-left: 16px;
-	padding-right: 64px;
 
 	font-family: -apple-system, BlinkMacSystemFont, Roboto, 'Segoe UI', sans-serif !important;
 	font-size: 14px !important;
@@ -1240,6 +1283,19 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 
 	display: flex;
 	align-items: center;
+
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+
+	-webkit-tap-highlight-color: transparent;
+}
+
+.BMLayoutEditorConstraintPopupOption {
+	padding-right: 64px;
 }
 
 .BMMenuTouch > .BMMenuItem {
@@ -1259,6 +1315,30 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	max-height: 24px;
 
 	margin-right: 16px;
+}
+
+/* The menu's text element should expand to fill all available space */
+.BMMenuItem > span {
+	flex-grow: 1;
+}
+
+.BMMenuItemDisclosure {
+	width: 24px;
+	height: 24px;
+
+	margin-left: 48px;
+	
+	font-weight: 600;
+
+	font-size: 18px;
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.BMMenuItemDisclosureSubmenu::after {
+	content: '›';
 }
 
 @keyframes BMMenuItemActiveAnimation {
@@ -1288,14 +1368,29 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	color: white;
 }
 
+.BMMenuSourceNodeShadow.BMMenuItem.BMMenuItemHighlighted {
+	background: white;
+	color: rgba(0, 0, 0, .8);
+}
+
 .BMLayoutEditorConstraintPopupOption:active, .BMMenuTouch > .BMMenuItem:hover {
 	background: transparent;
 	color: rgba(0, 0, 0, .8);
 }
 
 .BMMenuItem.BMMenuItemActive {
-	animation: .2s linear BMMenuItemActiveAnimation;
+	animation: .15s linear BMMenuItemActiveAnimation;
 	animation-fill-mode: both;
+}
+
+.BMMenuTouch > .BMMenuItem.BMMenuItemActive,
+.BMMenuTouch > .BMMenuItem.BMMenuItemHighlighted {
+	animation: none;
+	background: transparent;
+	color: rgba(0, 0, 0, .8);
+
+	backdrop-filter: brightness(90%);
+	-webkit-backdrop-filter: brightness(90%);
 }
 
 .BMLayoutEditorConstraintPopupOptionHighlighted, .BMMenuItemHighlighted {
@@ -1314,6 +1409,19 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 
 	.BMMenuTouch > .BMMenuItem {
 		border-bottom-color: rgba(255, 255, 255, .1);
+	}
+
+	.BMMenuTouch > .BMMenuItem.BMMenuItemActive,
+	.BMMenuTouch > .BMMenuItem.BMMenuItemHighlighted {
+		color: rgba(255, 255, 255, 1);
+	
+		backdrop-filter: brightness(110%);
+		-webkit-backdrop-filter: brightness(110%);
+	}
+
+	.BMMenuSourceNodeShadow.BMMenuItem.BMMenuItemHighlighted {
+		background: rgba(33, 33, 33, 1);
+		color: rgba(255, 255, 255, .9);
 	}
 
 	@keyframes BMMenuItemActiveAnimation {
@@ -1338,6 +1446,8 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 		}
 	}
 }
+
+/* #endregion */
 
 .BMLayoutEditorWorkspaceToolbarSizeClass .BMLayoutEditorConstraintPopupOption {
 	color: rgba(255, 255, 255, .9);

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -1124,7 +1124,7 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 /* #region - Menu container */
 
 .BMLayoutEditorConstraintPopupContainer, .BMMenuContainer {
-	position: absolute;
+	position: fixed;
 
 	left: 0px;
 	top: 0px;
@@ -1301,11 +1301,19 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 .BMMenuTouch > .BMMenuItem {
 	height: 44px;
 	line-height: 44px;
-	border-bottom: 1px solid rgba(0, 0, 0, .1);
+	border-top: 1px solid rgba(0, 0, 0, .1);
 }
 
-.BMMenuTouch > .BMMenuItem:last-child {
-	border-bottom-width: 0px;
+.BMMenuTouch > .BMMenuItem:first-child {
+	border-top-width: 0px;
+}
+
+.BMMenuTouch > .BMMenuItem.BMMenuItemHighlighted + .BMMenuItem {
+	border-top-color: rgba(0, 0, 0, .2);
+}
+
+.BMMenuTouch > .BMMenuItem.BMMenuItemHighlighted + .BMMenuDivider {
+	box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, .1) inset;
 }
 
 .BMMenuIcon {
@@ -1577,6 +1585,12 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	flex-shrink: 0;
 }
 
+.BMMenuTouch > .BMMenuDivider {
+	margin: 0;
+	height: 3px;
+	background: rgba(0, 0, 0, .1);
+}
+
 .BMLayoutEditorDetailsDividerCell {
 	background: rgba(0, 0, 0, .05);
 }
@@ -1600,7 +1614,7 @@ input:not(:checked) + .BMWindowSwitchGutter > .BMWindowSwitchKnob, .BMWindowSwit
 	flex-shrink: 0;
 }
 
-BMLayoutEditorDetailsItemBadge {
+.BMLayoutEditorDetailsItemBadge {
 	height: 16px;
 
 	border: 1px solid rgba(0, 0, 0, .1);

--- a/src/BMCoreUI.css
+++ b/src/BMCoreUI.css
@@ -626,7 +626,7 @@
 	background: rgba(0, 128, 255, 1);
 	
 	color: white;
-	font-family: -apple-system, BinkMacSystemFont, 'Roboto', 'Helvetica', 'Segoe UI', sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica', 'Segoe UI', sans-serif;
 	font-size: 14px;
 	font-weight: bold;
 	

--- a/src/BMView/BMLayoutConstraint_v2.5.js
+++ b/src/BMView/BMLayoutConstraint_v2.5.js
@@ -154,7 +154,7 @@ const _BMLayoutConstraintClasses = {BMLayoutConstraint, BMEqualAttributeLayoutCo
  * A constraint is a linear equation that takes the form of 
  * ```js
 view1.attribute1 = multiplier * view2.attribute2 + constant
-```
+``` 
  * where the equals sign can be replaced with an inequality sign as needed.
  * Note that despite looking like an assignment statement, the constraint expression is a mathematical equation and the layout
  * system may choose to modify either side (or even both) of the equation to fulfill the constraint's requirements.

--- a/src/BMView/BMMenu.js
+++ b/src/BMView/BMMenu.js
@@ -237,7 +237,7 @@ BMMenu.prototype = {
         if (this._node) {
             // When the icon size is changed while the menu is active
             // apply it to all menu items
-            for (const icon of this._node.querySelectorAll()) {
+            for (const icon of this._node.querySelectorAll('.BMMenuIcon')) {
                 BMCopyProperties(icon.style, {
                     width: size + 'px',
                     height: size + 'px'

--- a/src/BMView/BMMenuDelegate.js
+++ b/src/BMView/BMMenuDelegate.js
@@ -1,0 +1,55 @@
+// @type interface BMMenuDelegate
+
+/**
+ * The specification for a `BMMenuDelegate` object, which can optionally be used in conjunction with `BMTextField` objects and will receive various
+ * callbacks related to the text field's lifecycle.
+ */
+function BMMenuDelegate() {} // <constructor>
+
+BMMenuDelegate.prototype = {
+
+    /**
+     * Invoked by menus when they are about to be opened. This method is invoked before
+     * any associated animation runs and before the actual content is rendered.
+     * @param menu <BMMenu>     The calling menu.
+     */
+    menuWillOpen(menu) {},
+
+    /**
+     * Invoked by menus when they are about to be closed. This method is invoked before
+     * any associated animation runs.
+     * @param menu <BMMenu>     The calling menu.
+     */
+    menuWillClose(menu) {},
+
+    /**
+     * Invoked by menus after they are closed. This method is invoked after
+     * any associated animation runs and after their contents are removed from the document.
+     * @param menu <BMMenu>     The calling menu.
+     */
+    menuDidClose(menu) {},
+
+    /**
+     * Invoked by menus whenever a menu item is about to be selected.
+     * Delegates can implement this method to control whether the manu item may be selected or not.
+     * 
+     * Returning `YES` from this method will cause the item to be selected and the menu to close.
+     * Returning `NO` from this method will prevent the menu item from being selected and the menu will not close.
+     * 
+     * If this method is not implemented, all menu items may be selected.
+     * 
+     * @param menu <BMMenu>         The menu on which the item is about to be selected.
+     * @param item <BMMenuItem>     The menu item that is about to be selected.
+     * @returns <Boolean>           `YES` if the menu item should be selected, `NO` otherwise.
+     */
+    menuShouldSelectItem(menu, item) {},
+
+    /**
+     * Invoked by menus whenever a menu item has been selected.
+     * @param menu <BMMenu>         The menu on which the item was selected.
+     * @param item <BMMenuItem>     The menu item that was selected.
+     */
+    menuDidSelectItem(menu, item) {},
+}
+
+// @endtype

--- a/src/BMView/BMScrollView.js
+++ b/src/BMView/BMScrollView.js
@@ -103,7 +103,7 @@ BMScrollView.prototype = BMExtend({}, BMView.prototype, {
     },
 
     /**
-     * Invoked whenever the iScroll instance managing this scroll view's scrolling scrolls.
+     * Invoked whenever the iScroll instance managing this scroll view's scrolling.
      */
     _iScrollDidScroll() {
         this._scrollOffset = BMPointMake(this._iScroll.x, this._iScroll.y);

--- a/src/BMView/BMTextFieldDelegate.js
+++ b/src/BMView/BMTextFieldDelegate.js
@@ -47,7 +47,7 @@ BMTextFieldDelegate.prototype = {
     /**
      * Invoked whenever the contents in this text field change for any reason. This can be because of an input event,
      * the user pasting text or a suggestion being selected.
-     * Note that this method will not be invoked when manually setting the input node's `value`.
+     * Note that this method will not be invoked when programatically setting the input node's `value`.
      * 
      * Delegate objects can implement this method in place of standard event listeners to handle changes to this text field.
      * The contents of the text field can be retrieved via the standard `value` property on the text field's node.
@@ -58,9 +58,9 @@ BMTextFieldDelegate.prototype = {
     /**
      * Invoked whenever the user presses the return key while the text field has keyboard focus.
      * 
-     * Delegate objects can implement this method to customize the behaviour when the user presses the return key and also control whether the default action will take place.
-     * The default action for pressing the return key is to cause the text field to resign keyboard focus. If suggestions are used, the return key will also fill in the currently
-     * highlighted suggestion.
+     * Delegate objects can implement this method to customize the behaviour when the user presses the return key and also control 
+     * whether the default action will take place. The default action for pressing the return key is to cause the text field to 
+     * resign keyboard focus. If suggestions are used, the return key will also fill in the currently highlighted suggestion.
      * @param textField <BMTextField>       The calling text field.
      * @return <Boolean, nullable>          Defaults to `YES`. If set to `YES`, the standard behaviour will be invoked.
      */

--- a/src/BMView/BMTextFieldDelegate.js
+++ b/src/BMView/BMTextFieldDelegate.js
@@ -1,7 +1,7 @@
 // @type interface BMTextFieldDelegate
 
 /**
- * The specification for a `BMTextField` object, which can optionally be used in conjunction with `BMTextField` objects and will receive various
+ * The specification for a `BMTextFieldDelegate` object, which can optionally be used in conjunction with `BMTextField` objects and will receive various
  * callbacks related to the text field's lifecycle.
  */
 function BMTextFieldDelegate() {} // <constructor>
@@ -15,7 +15,7 @@ BMTextFieldDelegate.prototype = {
      * 
      * If this method is not implemented, suggestions and autocomplete will not be available.
 	 * @param textField <BMTextField>		The calling text field.
-     * @param text <String>                 
+     * @param text <String>                 The text for which to obtain suggestions.
      * @return <[String]>                   An array of string suggestions.
 	 */
     textFieldSuggestionsForText(textField, text) {},

--- a/src/BMViewLayoutEditor/BMLayoutEditorViewSettings.js
+++ b/src/BMViewLayoutEditor/BMLayoutEditorViewSettings.js
@@ -30,8 +30,11 @@ _BMLayoutEditorViewSettingsPanel.prototype = BMExtend(Object.create(_BMLayoutEdi
     _layoutTab: undefined, // <BMLayoutEditorSettingsTab>
 
     /**
-     * Designated initializer. Initializes this settings panel with the given settings view.
-     * @param view <_BMLayoutSettingsView>          The settings view.
+     * Designated initializer. Initializes this settings panel with the specified settings view.
+     * @param settingsView <_BMLayoutSettingsView>  The settings view.
+     * {
+     *  @param forView <BMView>                     The view whose settings will be displayed.
+     * }
      * @return <_BMLayoutEditorSettingsPanel>       This setttings panel.
      */
     initWithSettingsView(settingsView, {forView: view}) {

--- a/src/BMWindow/BMConfirmationPopup.js
+++ b/src/BMWindow/BMConfirmationPopup.js
@@ -182,7 +182,12 @@ BMAlertPopup.prototype = BMExtend(Object.create(BMWindow.prototype), {
     /**
      * The DOM node that was focused when this alert was opened.
      */
-    _previouslyActiveNode: undefined, // DOMNode
+    _previouslyActiveNode: undefined, // <DOMNode>
+
+    /**
+     * A handler that is invoked when the window resizes, used to reposition this window.
+     */
+    _centerHandler: undefined, // <void ^()>
 
     /**
      * Designated initializer. Initializes this alert popup with the given labels.
@@ -291,6 +296,15 @@ BMAlertPopup.prototype = BMExtend(Object.create(BMWindow.prototype), {
     },
 
     // @override - BMWindow
+    bringToFrontAnimated() {
+        this._resizeHandler = () => this.needsLayout = YES;
+
+        window.addEventListener('resize', this._resizeHandler);
+
+        return BMWindow.prototype.bringToFrontAnimated.apply(this, arguments);
+    },
+
+    // @override - BMWindow
     dismissAnimated() {
         // Since the window can be dismissed by clicking outside in certain cases, this would be equivalent to pressing "OK".
         if (this._result == BMConfirmationPopupResult.Undecided) {
@@ -302,7 +316,13 @@ BMAlertPopup.prototype = BMExtend(Object.create(BMWindow.prototype), {
             this._previouslyActiveNode.focus();
         }
 
+        window.removeEventListener('resize', this._resizeHandler);
+
         return BMWindow.prototype.dismissAnimated.apply(this, arguments);
+    },
+
+    windowDidClose() {
+        this.release();
     }
 
 });

--- a/src/BMWindow/BMPopover/BMPopover.js
+++ b/src/BMWindow/BMPopover/BMPopover.js
@@ -404,8 +404,7 @@ BMPopover.prototype = BMExtend(Object.create(BMWindow.prototype), {
 
         this.frame = frame;
 
-        const innerFrame = frame.copy();
-
+        // Determine the indicator's position along its edge
         let indicatorPosition;
         switch (direction) {
             case BMPopoverIndicatorDirection.Bottom:
@@ -418,6 +417,8 @@ BMPopover.prototype = BMExtend(Object.create(BMWindow.prototype), {
                 break;
         }
 
+        // Create an inner frame to be used by the various paths
+        const innerFrame = frame.copy();
         innerFrame.origin = BMPointMake();
 
         const pathContent = `${this._pathForPopoverWithFrame(innerFrame, {indicatorSize: this._indicatorSize, position: indicatorPosition, direction, radius: this._borderRadius})}`;

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -1793,13 +1793,13 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 		if (BMWindow._keyWindow == this && !this._modal) {
 			this.node.classList.remove('BMKeyWindow');
 			this.node.classList.add('BMWindowInactive');
-			if (this.delegate && this.delegate.windowDidResignKeyWindow) {
-				this.delegate.windowDidResignKeyWindow(this);
-			}
 			BMWindow._keyWindow = undefined;
 
 			for (let toolWindow of this._toolWindows) {
 				toolWindow.hide();
+			}
+			if (this.delegate && this.delegate.windowDidResignKeyWindow) {
+				this.delegate.windowDidResignKeyWindow(this);
 			}
 		}
 	},

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -1867,6 +1867,11 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 	 * This instance should not be reused after invoking this method.
 	 */
 	release() {
+		if (this.__released) {
+            // This needs to be handled because of the way Thingworx DOM nodes are removed and recreated in the composer
+            return;
+        }
+
 		if (BMWindow._keyWindow == this) BMWindow._keyWindow = undefined;
 
 		if (this._boundViewportDidResize) {

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -257,30 +257,38 @@ BMWindow.unregisterShowcaseElement = function (element) {
 BMWindow.enterShowcase = async function () {
 	if (BMWindow._isShowcasing) return;
 
+	// Set a background color for the body to have a good contrast between the windows
+	// and the "empty space"
 	document.body.style.backgroundColor = 'rgb(60, 60, 60)';
 
 	BMWindow._isShowcasing = YES;
 
+	// Set up a handler to exit the showcase when clicking outside of any window
 	document.body.addEventListener('click', BMWindow.exitShowcase);
 
+	// Only include non-minimized windows in the showcase
 	let openWindows = BMWindow._windows.filter(value => !value._minimizedWindow);
 
-	let viewportFrame = BMRectMake(0, 0, window.innerWidth, window.innerHeight);
-
+	// Add any window-like elements that have been registered to participate in the showcase
 	for (let element of BMWindow._showcaseElements) {
 		openWindows.unshift(element);
 	}
 
 	openWindows.forEach(window => {
+		// For each window, create a mask that consumes mouse events instead of the windows
+		// and disable pointer events for the windows
 		window.node.classList.add('BMWindowShowcaseWindow');
 
 		let selector = document.createElement('div');
 		selector.classList.add('BMWindowShowcaseWindowSelector');
 		selector.addEventListener('click', event => {
 			if (window.becomeKeyWindow) {
+				// If the clicked element is a window, make it the key window
 				window.becomeKeyWindow();
 			}
 			else {
+				// If a non-window element is clicked, bring it to the front by hiding
+				// all windows
 				BMWindow.hideAll();
 			}
 			BMWindow.exitShowcase();
@@ -289,16 +297,30 @@ BMWindow.enterShowcase = async function () {
 		window.node.appendChild(selector);
 	});
 
+
+	let viewportFrame = BMRectMake(0, 0, window.innerWidth, window.innerHeight);
+	// Create a copy of each window's frame which will be used to determine where to place each window
+	// in the showcase
 	let sourceRects = openWindows.map(window => window._fullScreen ? viewportFrame.copy() : window.frame.copy());
+
+	// Retain a copy of the original frames to determine what transforms to apply to each window
 	let originalRects = sourceRects.map(rect => rect.copy());
+
+	// Set to NO when no windows overlap
 	let overlap;
 
+	// Initialize the bounds with the viewport frame; this will expand to represent the entire area
+	// used by all windows as they get pushed apart
 	let bounds = viewportFrame.copy();
 
+	// Because the algorithm works through multiple iterations where each intersecting windows
+	// are pushed apart slightly, set a maximum number of iterations to avoid situations
+	// where a fully non-intersecting layout cannot be obtained in an acceptable amount of time
 	for (let i = 0; i < BM_WINDOW_SHOWCASE_MAX_ITERATIONS; i++) {
 
 		for (let j = 0; j < sourceRects.length; j++) {
 			for (let k = 0; k < sourceRects.length; k++) {
+				// Iterate through each pair of windows and push apart those windows that intersect
 				if (j != k && sourceRects[j].intersectsRect(sourceRects[k])) {
 					overlap = YES;
 	
@@ -307,11 +329,15 @@ BMWindow.enterShowcase = async function () {
 
 					let difference = rect2.center.pointBySubtractingPoint(rect1.center);
 
+					// If the windows have the same center point, choose a random direction
+					// in which to push them apart
 					if (!difference.x && !difference.y) {
 						difference.x = Math.random() * 2 - 1;
 						difference.y = Math.random() * 2 - 1;
 					}
 
+					// Adjust the direction in which the windows are pushed apart to maintain a similar
+					// aspect ratio between the bounds and the viewport
 					if (bounds.height / bounds.width > viewportFrame.height / viewportFrame.width) {
 						difference.x = difference.x * 2;
 					}
@@ -319,13 +345,16 @@ BMWindow.enterShowcase = async function () {
 						difference.y = difference.y * 2;
 					}
 
+					// Normalize the distance
 					let length = Math.sqrt(difference.x * difference.x + difference.y * difference.y);
 					difference.x = difference.x * 20 / length;
 					difference.y = difference.y * 20 / length;
 
+					// Push the two windows apart in opposite directions
 					rect1.offsetWithX(-difference.x, {y: -difference.y});
 					rect2.offsetWithX(difference.x, {y: difference.y});
 
+					// Extend the bounds to contain the windows in their new positions
 					bounds = bounds.rectByUnionWithRect(rect1).rectByUnionWithRect(rect2);
 
 				}
@@ -335,11 +364,14 @@ BMWindow.enterShowcase = async function () {
 		if (!overlap) break;
 	}
 
+	// Determine how much the windows need to be shrinked to fit on screen
 	let scale = Math.min(1, viewportFrame.width / bounds.width, viewportFrame.height / bounds.height);
 
 	for (let rect of sourceRects) {
+		// Adjust the rect's origin so that it is relative to the bounds instead of the viewport
 		rect.offset(-bounds.left, -bounds.top);
 
+		// Apply the scale
 		rect.origin.x = rect.origin.x * scale;
 		rect.origin.y = rect.origin.y * scale;
 
@@ -351,11 +383,8 @@ BMWindow.enterShowcase = async function () {
 	BMAnimateWithBlock(() => {
 		BMAnimationContextEnableWebAnimations();
 
-		/*let header = document.getElementById('twStudioHeader');
-		let headerController = BMAnimationContextGetCurrent().controllerForObject(header, {node: header});
-		headerController.registerBuiltInProperty('translateY', {withValue: -header.offsetHeight + 'px'});*/
-
 		for (let i = 0; i < sourceRects.length; i++) {
+			// For each window, determine which transforms to apply and animate to them
 			let transformRect = originalRects[i].rectWithTransformToRect(sourceRects[i]);
 	
 			let controller = BMAnimationContextGetCurrent().controllerForObject(openWindows[i].node, {node: openWindows[i].node});
@@ -391,19 +420,18 @@ BMWindow.exitShowcase = function (event) {
 
 	BMWindow._isShowcasing = NO;
 	
+	// Clear the event handlers set up for the showcase
 	document.body.removeEventListener('click', BMWindow.exitShowcase);
 	document.body.removeEventListener('wheel', BMWindow._wheelHandler, YES);
 
 	let openWindows = BMWindow._windows.filter(value => !value._minimizedWindow);
-	/*let twStudio = document.querySelector('#twStudioBody');
-	let pageWindow = {node: twStudio};
-	openWindows.unshift(pageWindow);*/
 
 	for (let element of BMWindow._showcaseElements) {
 		openWindows.unshift(element);
 	}
 
 	openWindows.forEach(window => {
+		// Clear the classes and masks created for each window
 		window.node.classList.remove('BMWindowShowcaseWindow');
 
 		let selector = window.node.querySelector('.BMWindowShowcaseWindowSelector');
@@ -413,11 +441,8 @@ BMWindow.exitShowcase = function (event) {
 	BMAnimateWithBlock(() => {
 		BMAnimationContextEnableWebAnimations();
 
-		/*let header = document.getElementById('twStudioHeader');
-		let headerController = BMAnimationContextGetCurrent().controllerForObject(header, {node: header});
-		headerController.registerBuiltInProperty('translateY', {withValue: '0px'});*/
-
 		for (let i = 0; i < openWindows.length; i++) {
+			// For each window, animate back to no transforms
 			let controller = BMAnimationContextGetCurrent().controllerForObject(openWindows[i].node, {node: openWindows[i].node});
 			controller.registerBuiltInPropertiesWithDictionary({
 				translateX: '0px',

--- a/src/BMWindow/BMWindow.js
+++ b/src/BMWindow/BMWindow.js
@@ -1427,6 +1427,7 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 					self._blocker.style.backdropFilter = 'blur(' + ((1 - complete) * 15).toFixed(2) + 'px)';
 				},*/
 				complete: function () {
+					self.windowDidClose();
 					if (self.delegate && self.delegate.windowDidClose) {
 						self.delegate.windowDidClose(self);
 					}
@@ -1467,12 +1468,22 @@ BMWindow.prototype = BMExtend(Object.create(BMView.prototype), {
 			
 			this._window.style.opacity = 0;
 			this._window.style.display = 'none';
+
+			self.windowDidClose();
 			
 			if (self.delegate && self.delegate.windowDidClose) {
 				self.delegate.windowDidClose(self);
 			}
 			if (args && args.completionHandler) args.completionHandler();
 		}
+	},
+
+	/**
+	 * Invoked after this window closes. Subclasses overriding this method must invoked
+	 * the superclass method at some point in their implementation.
+	 */
+	windowDidClose() {
+
 	},
 
 	/**


### PR DESCRIPTION
## BMCollectionView

Resolves an issue where calling `updateEntireDataAnimated` with the animated parameter set to `NO` would cause the completion handler to never be invoked.

## BMCollectionViewLayout

The `shouldInvalidateLayoutForBoundsChange` method now takes in an additional argument `fromBounds` which are the bounds prior to changing.

## BMCollectionViewDelegate

The `collectionViewBoundsDidChange` method now takes in an additional argument `fromBounds` which are the bounds prior to changing.

## BMWindow

Resolves an issue where `BMWindow` would call `windowDidResignKeyWindow` while still being the key window.

A new `windowDidClose` method is invoked on windows after they closes. Subclasses can override this method to perform any cleanup necessary after being dismissed.

Invoking the `release` method on a window that was already released will now have no effect.

## BMAlertPopup

This window will now reposition itself whenever the viewport is resized.

Alert popups and any subclasses will now automatically `release` themselves after closing.