### PR TITLE
Fix iscroll event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.9.1
+
+## BMCollectionView
+
+Resolves an issue that caused items that were accepted via drag & drop to not play the appropriate animation when dropped.
+
+Resolves an issue where `preventDefault` was invoked on events originating from elements with the `BMCollectionViewCellEventHandler` class while using iScroll.
+
 # 2.9
 
 ## BMCollectionView

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-core-ui",
     "packageName": "BMCoreUI",
     "moduleName": "BMCoreUI",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A collection of reusable UI classes.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",

--- a/src/BMCollectionView/BMCollectionView.js
+++ b/src/BMCollectionView/BMCollectionView.js
@@ -5532,7 +5532,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 			if (self._droppedShadows) {
 				self._droppedShadows.forEach(shadow => {
 					if (shadow.transform) {
-						BMHook(shadow.node, {rotateZ: shadow.rotation});
+						BMHook(shadow.node, {rotateZ: shadow.rotation + 'deg', translateX: '0px', translateY: '0px'});
 						let controller = BMAnimationContextGetCurrent().controllerForObject(shadow, {node: shadow.node});
 						controller.registerBuiltInProperty('translateX', {withValue: shadow.transform.origin.x + 'px'});
 						controller.registerBuiltInProperty('translateY', {withValue: shadow.transform.origin.y + 'px'});
@@ -5542,7 +5542,7 @@ BMCollectionView.prototype = BMExtend(BM_COLLECTION_VIEW_USE_BMVIEW_SUBCLASS ? O
 						controller.registerBuiltInProperty('opacity', {withValue: 0});
 					}
 					else {
-						BMHook(shadow.node, {rotateZ: shadow.rotation});
+						BMHook(shadow.node, {rotateZ: shadow.rotation + 'deg'});
 						let controller = BMAnimationContextGetCurrent().controllerForObject(shadow, {node: shadow.node});
 						controller.registerBuiltInProperty('scaleX', {withValue: .33});
 						controller.registerBuiltInProperty('scaleY', {withValue: .33});

--- a/src/iScroll/iscroll-probe.js
+++ b/src/iScroll/iscroll-probe.js
@@ -447,7 +447,12 @@ IScroll.prototype = {
 			return;
 		}
 
-		if ( this.options.preventDefault && !utils.isBadAndroid && !utils.preventDefaultException(e.target, this.options.preventDefaultException) ) {
+		if ( 
+			this.options.preventDefault && 
+			!utils.isBadAndroid && 
+			!utils.preventDefaultException(e.target, this.options.preventDefaultException) &&
+			!e.target.classList.contains('BMCollectionViewCellEventHandler') && !e.target.parentNode.classList.contains('BMCollectionViewCellEventHandler')
+		) {
 			e.preventDefault();
 		}
 
@@ -597,7 +602,10 @@ IScroll.prototype = {
 			return;
 		}
 
-		if ( this.options.preventDefault && !utils.preventDefaultException(e.target, this.options.preventDefaultException) ) {
+		if (
+			this.options.preventDefault && !utils.preventDefaultException(e.target, this.options.preventDefaultException) &&
+			!e.target.classList.contains('BMCollectionViewCellEventHandler') && !e.target.parentNode.classList.contains('BMCollectionViewCellEventHandler')
+		) {
 			e.preventDefault();
 		}
 


### PR DESCRIPTION
## BMCollectionView

Resolves an issue that caused items that were accepted via drag & drop to not play the appropriate animation when dropped.

Resolves an issue where `preventDefault` was invoked on events originating from elements with the `BMCollectionViewCellEventHandler` class while using iScroll.