### PR TITLE
2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.9.2
+
+## BMCollectionViewFlowLayout
+
+Resolves an issue where the scrollbar width was not taken into account when measuring cells when using automatic cell size.
+
 # 2.9.1
 
 ## BMCollectionView

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-core-ui",
     "packageName": "BMCoreUI",
     "moduleName": "BMCoreUI",
-    "version": "2.9.1",
+    "version": "2.9.2",
     "description": "A collection of reusable UI classes.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",


### PR DESCRIPTION
## BMCollectionViewFlowLayout

Resolves an issue where the scrollbar width was not taken into account when measuring cells when using automatic cell size.