### PR TITLE
2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,65 @@
+# 2.11.0
+
+## BMAnimationContext
+
+All animation contexts are now "blocking" regardless of what value is set for this argument when present.
+
+The `queue` property can no longer be specified on animation contexts.
+
+Resolves an issue where the complete callback was not invoked for an animation context when a specific item's animation was cancelled.
+
+Resolves a leak that occurred when creating animations with a delay.
+
+## BMCollectionViewReuseState
+
+A new `BMCollectionViewReuseState` enum contains constants which describe the reuse state of a cell.
+
+## BMCollectionViewCell
+
+The `_isMeasuring` property is now protected instead of private.
+
+Resolves an issue where the `invalidate` method was incorrectly invoked when the cell could be reused.
+
+## BMCollectionView
+
+Added a new `dataSource` property that can be set to a data source object, instead of the previous `dataSet` property. The `dataSet` property has now been deprecated and updating either of these properties will cause an adapter object to be created for the other object.
+
+When a `dataSource` object is set, the deprecated `updateCell`, `updateSupplementaryView`, `contentsForCellWithReuseIdentifier` and `contentsForSupplementaryViewWithIdentifier` methods are no longer invoked. Attempting to invoke these methods on the data set adapter object will cause an error to be thrown.
+
+The `updateEntireDataAnimated` method may now be invoked while a previous animated data update is already in progress.
+
+The intro animation, if running is now considered a data update; the `isUpdatingData` property will be set to `YES` and when it ends, data completion callbacks will be invoked.
+
+A new `dataUpdated` property can be used to obtain a promise that resolves when the animations associated with the current data update finish.
+
+Resolves an issue where scrollbars were not properly added or removed if the content size changed following an animated data update.
+
+Resolves an issue on windows touch devices that caused non-left clicks on collection view cells to be interpreted as left clicks.
+
+## BMCollectionViewDataSource
+
+A new `BMCollectionViewDataSource` interface may be implemented by objects, replacing the previous `BMCollectionViewDataSet` interface which is now deprecated. The data source interface defines the same methods as the previous data set interface, except for all previously deprecated methods which are now removed. In addition, the data source interface uses the delegate pattern so that all methods now receive the calling collection view as their first argument, allowing a single data source to be used with multiple collection views.
+
+## BMCollectionViewFlowLayout
+
+The static `flowLayout` factory method will now correctly return a subclass instance when inherited.
+
+## BMCollectionViewMasonryLayout
+
+The static `masonryLayout` factory method will now correctly return a subclass instance when inherited.
+
+## BMCollectionViewStackLayout
+
+The static `stackLayout` factory method will now correctly return a subclass instance when inherited.
+
+## BMCollectionViewTileLayout
+
+The static `tileLayout` factory method will now correctly return a subclass instance when inherited.
+
+## BMMonacoCodeEditor
+
+Resolves an issue with the monaco config where import statements written in typescript were converted into require calls.
+
 # 2.10.5
 
 ## BMCollectionViewFlowLayout

--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -11,22 +11,6 @@ import babel from 'gulp-babel';
 import {createTypeScriptDefinitionsWithContent} from './DTSGen.mjs';
 import packageJson from './package.json' assert { type: "json" };
 
-
-// const {createTypeScriptDefinitionsWithContent} = require('./DTSGen');
-// const packageJson = require('./package.json');
-
-// const path = require('path');
-// const fs = require('fs');
-// const xml2js = require('xml2js');
-// const deleteEmpty = require('delete-empty');
-
-// const { series, src, dest } = require('gulp');
-// const concat = require('gulp-concat');
-// const terser = require('gulp-terser');
-// const babel = require('gulp-babel');
-
-// const packageJson = require('./package.json');
-
 /**
  * Files to remove from the build.
  */
@@ -35,6 +19,7 @@ const removeFiles = [
     // These files represent interface definitions and are not meant to be included in the final package
     'BMCollectionView/BMCollectionViewDelegate.js',
     'BMCollectionView/BMCollectionViewDataSet.js',
+    'BMCollectionView/BMCollectionViewDataSource.js',
     'BMWindow/BMWindowDelegate.js',
     'BMViewLayoutEditor/BMLayoutVariableProvider.js',
     'BMView/BMMenuDelegate.js',
@@ -139,6 +124,7 @@ const DTSFiles = [
     'BMCollectionView/BMCollectionViewStackLayout.js', 
     'BMCollectionView/BMCollectionView.js', 
     'BMCollectionView/BMCollectionViewDataSet.js', 
+    'BMCollectionView/BMCollectionViewDataSource.js', 
     'BMCollectionView/BMCollectionViewDelegate.js', 
     'BMWindow/BMWindow.js', 
     'BMWindow/BMToolWindow.js', 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-core-ui",
     "packageName": "BMCoreUI",
     "moduleName": "BMCoreUI",
-    "version": "2.10.5",
+    "version": "2.11.0",
     "description": "A collection of reusable UI classes.",
     "thingworxServer": "http://localhost:8915",
     "thingworxUser": "Administrator",

--- a/src/BMCodeEditor/BMCodeEditor.js
+++ b/src/BMCodeEditor/BMCodeEditor.js
@@ -474,7 +474,7 @@ BMExtend(BMMonacoCodeEditor.prototype, BMCodeEditor.prototype, {
 			experimentalDecorators: YES,
 			strict: YES,
 			inlineSourceMap: YES,
-			module: monaco.languages.typescript.ModuleKind.CommonJS,
+			module: monaco.languages.typescript.ModuleKind.ES2015,
 			noImplicitUseStrict: YES
 		});
 		
@@ -487,7 +487,7 @@ BMExtend(BMMonacoCodeEditor.prototype, BMCodeEditor.prototype, {
 			inlineSources: YES,
 			noImplicitUseStrict: YES,
 			alwaysStrict: NO,
-			module: monaco.languages.typescript.ModuleKind.None,
+			module: monaco.languages.typescript.ModuleKind.ES2015,
 			useDefineForClassFields: NO,
 		});
 			

--- a/src/BMCollectionView/BMCollectionViewDataSet.js
+++ b/src/BMCollectionView/BMCollectionViewDataSet.js
@@ -1,6 +1,9 @@
 // @type interface BMCollectionViewDataSet<T = any>
 
 /**
+ * @deprecated Use `BMCollectionViewDataSource` instead.
+ * 
+ * ------
  * The specification for a BMCollectionViewDataSet object, which is used to provide information to the collection view regarding the number
  * of sections and objects that it should display, as well as their contents and the contents of any supplementary views defined by the current layout.
  *

--- a/src/BMCollectionView/BMCollectionViewDataSource.js
+++ b/src/BMCollectionView/BMCollectionViewDataSource.js
@@ -1,0 +1,170 @@
+// @type interface BMCollectionViewDataSource<T = any>
+
+/**
+ * Describes a `BMCollectionViewDataSource` object, which is used to provide information to the collection view regarding the number
+ * of sections and objects that it should display, as well as their contents and the contents of any supplementary views defined by the current layout.
+ *
+ * There is no built-in concrete implementation for this interface; all objects implementing this interface must define their own methods.
+ */
+function BMCollectionViewDataSet() {} // <constructor>
+
+BMCollectionViewDataSet.prototype = {
+
+	/**
+	 * Returns the number of sections in the data set.
+     * @param collectionView <BMCollectionView>         The collection view for which the number of sections should be returned.
+	 * @return <Int>			                        The number of sections.
+	 */
+	/*required*/ collectionViewNumberOfSections: function (collectionView) {},
+	
+	/**	
+	 * Returns the number of cells in the given section.
+     * @param collectionView <BMCollectionView>         The collection view for which the number of objects should be returned.
+	 * @param index <Int>		                        The section's index.
+	 * @return <Int>			                        The number of cells.
+	 */
+	/*required*/ collectionViewNumberOfObjectsInSectionAtIndex: function (collectionView, index) {},
+	
+	/**
+	 * Returns the index path for the object with the specified section and row indexes.
+     * @param collectionView <BMCollectionView>         The collection view for which the number of objects should be returned.
+	 * @param row <Int>						            The object's index within the section.
+	 * {
+	 * 	@param inSectionAtIndex <Int>		            The section's index.
+	 * }
+	 * @return <BMIndexPath<T>, nullable>	            The index path if these indexes are part of the data set,
+	 * 										            `undefined` otherwise. `undefined` may only be returned during
+	 * 										            animated data updates while `isUsingOldData` returns `YES`.
+	 */
+	 /*required*/ collectionViewIndexPathForObjectAtRow: function (collectionView, row, {inSectionAtIndex: section}) {},
+	 
+	/**
+	 * Returns the index path for the specified object.
+     * @param collectionView <BMCollectionView>         The collection view for which the index path should be returned.
+	 * @param object <Object>				            The object.
+	 * @return <BMIndexPath<T>, nullable>	            The index path, if the object is part of the data set,
+	 * 										            `undefined` otherwise. `undefined` may only be returned during
+	 * 										            animated data updates while `isUsingOldData` returns `YES`.
+	 */
+	 /*required*/ collectionViewIndexPathForObject: function (collectionView, object) {},
+	 
+	/**
+	 * Returns the cell for the object at the specified index path.
+	 * To retrieve a cell, use the collection view's `dequeueCellForReuseIdentifier` method,
+	 * passing in the appropriate identifier for your cell depending on the item at the specified index path.
+	 * The data source object defines the reuse identifiers that the cells have.
+     * @param collectionView <BMCollectionView>         The collection view for which the cell should be returned.
+	 * @param indexPath <BMIndexPath<T>>		        The index path.
+	 * @return <BMCollectionViewCell>			        The cell.
+	 */
+	 /*required*/ collectionViewCellForItemAtIndexPath: function (collectionView, indexPath) {},
+	 
+	/**
+	 * Returns the cell for the supplementary view of the specified type at the specified index path.
+	 * To retrieve a cell, use the collection view's `dequeueCellForSupplementaryViewWithIdentifier`,
+	 * passing in the supplementary view's type as the parameter.
+	 * Both the supplementary's view kind and its index path are defined entirely by the layout object
+     * and the data source must not return a supplementary view of a different kind from this method.
+     * @param collectionView <BMCollectionView>         The collection view for which the cell should be returned.
+	 * @param identifier <String>				        The supplementary view's type identifier.
+	 * {
+	 *	@param atIndexPath <BMIndexPath<T>>		        The supplementary view's index path.
+	 * }
+	 * @return <BMCollectionViewCell>			        The cell.
+	 */
+	 /*required*/ collectionViewCellForSupplementaryViewWithIdentifier: function (collectionView, identifier, {atIndexPath: indexPath}) {},
+	 
+	/**
+	 * If this data set performs full data updates, this function is required. For data sets that never update, or those that
+     * can perform delta updates, this method is optional.
+	 * This function may be invoked by the collection view during a full data update to access the old data set.
+	 * When this function is invoked with the parameter set to `YES`, the data set object should return values from the old data set
+	 * for all data and index path queries.
+	 * When this function is invoked with the parameter set to `NO`, the data set object should return values from the new data set.
+	 * Before the update is finished, the collection view will always invoke this method with the parameter set to `NO`.
+     * @param collectionView <BMCollectionView>         The collection view that is switching the data set.
+	 * @param use <Boolean>			                    `YES` if the data set should switch to the old data, `NO` if it should switch to the new data.
+	 */
+	collectionViewUseOldData: function (collectionView, use) {},
+	 
+	/**
+	 * If this data set performs full data updates, this function is required. For data sets that never update, or those that
+     * can perform delta updates, this method is optional.
+	 * This function may be invoked by the collection view during a full data update to determine if this data set is currently serving the previous data.
+	 * The data set must return YES if it is serving up the old data, NO otherwise.
+     * @param collectionView <BMCollectionView>         The collection view whose old data set should be retrieved.
+	 * @return <Boolean>			                    YES if this data source is currently serving the old data, NO otherwise.
+	 */
+	 /*required*/ collectionViewIsUsingOldData: function (collectionView) {},
+	 
+	/**
+	 * This method must be implemented by data set objects that support moving items for interactive drag gestures.
+	 * Data set objects implementing this method are expected to update their internal data structures to match
+	 * the item's new position, then trigger a data update to run on the collection view.
+	 * Optionally, data sets may reject the change and not perform any action.
+     * 
+	 * ---
+	 * For collection views that support moving items, this method must be implemented by the data sets these collection views
+	 * use. In this case, data sets that don't support moving items may simply return `NO` from this method.
+     * @param collectionView <BMCollectionView>         The collection view that is moving the item.
+	 * @param indexPath <BMIndexPath<T>>			    The item's current index path.
+	 * {
+	 * 	@param toIndexPath <BMIndexPath<T>>		        The index path to which the item should move.
+	 * }
+	 * @return <Boolean>						        `YES` if the data set has performed the requested change, `NO` otherwise.
+	 */
+    collectionViewMoveItemFromIndexPath: function (collectionView, indexPath, {toIndexPath: toIndexPath}) {},
+	 
+	/**
+	 * This method may be implemented by data set objects that support moving items for interactive drag gestures.
+	 * Data set objects implementing this method are expected to update their internal data structures to match
+	 * the items' new positions, then trigger a data update to run on the collection view.
+	 * Optionally, data sets may reject the change and not perform any action or only partially accept the update
+	 * and move just some of the items.
+	 * The order of the items in the array is guaranteed to be such that the target index paths are in ascending order.
+	 * Implementing this method is optional and if it is not implemented, collection view will repeatedly invoke
+	 * `moveItemFromIndexPath(_, {toIndexPath})` passing in each of the items that need to be moved.
+     * @param collectionView <BMCollectionView>     The collection view that is moving the items.
+	 * @param indexPaths <[BMIndexPath<T>]>		    An array of index paths identifying which items have to be moved.
+	 * {
+     *  @param toIndexPath <BMIndexPath<T>>		    The starting index path to which the items should move. This represents the index path of the current layout
+	 * 											    before any items may have moved. It is the data source's responsibility to adjust this index path as the items shift
+	 * 											    within its data structure.
+	 * }
+	 * @return <[BMIndexPath<T>]>					An array of index paths specifying the positions of the items after they have been moved.
+	 * 											    The index paths in this array are not required to match either of the lists supplied by
+	 *												collection view.
+	 */
+    collectionViewMoveItemsFromIndexPaths: function (collectionView, indexPaths, {toIndexPath: toIndexPath}) {},
+
+	 
+    /**
+     * This method may be implemented by data source objects that support removing items for interactive drag gestures.
+     * Data source objects implementing this method are expected to update their internal data structures to remove
+     * the items, then trigger a data update to run on the collection view.
+     * Optionally, data sources may reject the change and not perform any action or only partially accept the update
+     * and remove just some of the items, by changing their internal data structures appropriately.
+     * The order of the items in the array is guaranteed to be such that the target index paths are in ascending order.
+     * @param collectionView <BMCollectionView>     The collection view that is removing the items.
+     * @param indexPaths <[BMIndexPath<T>]>		    An array of index paths identifying which items have to be removed.
+     */
+    collectionViewRemoveItemsAtIndexPaths: function (collectionView, indexPaths) {},
+	 
+    /**
+     * This method may be implemented by data source objects that support transferring items from another collection view.
+     * Data source objects implementing this method are expected to update their internal data structures to add
+     * the items, then trigger a data update to run on the collection view. This data update must be triggered before
+     * this method returns for the appropriate animation to play on the items being transferred.
+     * Optionally, data sources may reject the change and not perform any action or only partially accept the update
+     * and add just some of the items, by changing their internal data structures appropriately.
+     * @param collectionView <BMCollectionView>     The collection view into which items are being inserted.
+     * @param items <[AnyObject]>					An array of objects to add to the collection view.
+     * {
+     *  @param toIndexPath <BMIndexPath<T>>		    The starting index path to which the items should be inserted.
+     * }
+     */
+    collectionViewInsertItems: function (collectionView, items, {toIndexPath: toIndexPath}) {},
+
+};
+
+// @endtype

--- a/src/BMCollectionView/BMCollectionViewFlowLayout.js
+++ b/src/BMCollectionView/BMCollectionViewFlowLayout.js
@@ -41,6 +41,7 @@ export var BMCollectionViewTableLayoutSupplementaryView = Object.freeze({ // <en
 
 /**
  * @deprecated Use `BMCollectionViewFlowLayout` with the `maximumCellsPerRow` property set to `1`.
+ * 
  * --------------------------------------
  * A basic layout implementation, the BMCollectionViewTableLayout will lay out its elements as a list where each row can have
  * either a fixed height or a variable height.
@@ -4964,7 +4965,7 @@ BMCollectionViewFlowLayout.prototype = BMExtend(Object.create(BMCollectionViewLa
  * @return <BMCollectionViewFlowLayout>		A flow layout.	 
  */
 BMCollectionViewFlowLayout.flowLayout = function () {
-	return new BMCollectionViewFlowLayout();
+	return new this();
 }
 
 // @endtype

--- a/src/BMCollectionView/BMCollectionViewMasonryLayout.js
+++ b/src/BMCollectionView/BMCollectionViewMasonryLayout.js
@@ -625,7 +625,7 @@ BMCollectionViewMasonryLayout.prototype = BMExtend({}, BMCollectionViewLayout.pr
  * @returns <BMCollectionViewMasonryLayout>		A masonry layout.
  */
 BMCollectionViewMasonryLayout.masonryLayout = function () {
-	return new BMCollectionViewMasonryLayout();
+	return new this();
 };
 
 // @endtype

--- a/src/BMCollectionView/BMCollectionViewStackLayout.js
+++ b/src/BMCollectionView/BMCollectionViewStackLayout.js
@@ -628,7 +628,7 @@ BMCollectionViewStackLayout.prototype = BMExtend({}, BMCollectionViewLayout.prot
  * @returns <BMCollectionViewStackLayout>	A stack layout.
  */
 BMCollectionViewStackLayout.stackLayout = function () {
-	return new BMCollectionViewStackLayout();
+	return new this();
 }
 
 // @endtype

--- a/src/BMCollectionView/BMCollectionViewTileLayout.js
+++ b/src/BMCollectionView/BMCollectionViewTileLayout.js
@@ -1260,7 +1260,7 @@ BMCollectionViewTileLayout.prototype = BMExtend({}, BMCollectionViewLayout.proto
  * @return <BMCollectionViewTileLayout>		A tile layout.
  */
 BMCollectionViewTileLayout.tileLayout = function () {
-	return new BMCollectionViewTileLayout();
+	return new this();
 };
 
 // @endtype


### PR DESCRIPTION
# 2.11.0

## BMAnimationContext

All animation contexts are now "blocking" regardless of what value is set for this argument when present.

The `queue` property can no longer be specified on animation contexts.

Resolves an issue where the complete callback was not invoked for an animation context when a specific item's animation was cancelled.

Resolves a leak that occurred when creating animations with a delay.

## BMCollectionViewReuseState

A new `BMCollectionViewReuseState` enum contains constants which describe the reuse state of a cell.

## BMCollectionViewCell

The `_isMeasuring` property is now protected instead of private.

Resolves an issue where the `invalidate` method was incorrectly invoked when the cell could be reused.

## BMCollectionView

Added a new `dataSource` property that can be set to a data source object, instead of the previous `dataSet` property. The `dataSet` property has now been deprecated and updating either of these properties will cause an adapter object to be created for the other object.

When a `dataSource` object is set, the deprecated `updateCell`, `updateSupplementaryView`, `contentsForCellWithReuseIdentifier` and `contentsForSupplementaryViewWithIdentifier` methods are no longer invoked. Attempting to invoke these methods on the data set adapter object will cause an error to be thrown.

The `updateEntireDataAnimated` method may now be invoked while a previous animated data update is already in progress.

The intro animation, if running is now considered a data update; the `isUpdatingData` property will be set to `YES` and when it ends, data completion callbacks will be invoked.

A new `dataUpdated` property can be used to obtain a promise that resolves when the animations associated with the current data update finish.

Resolves an issue where scrollbars were not properly added or removed if the content size changed following an animated data update.

Resolves an issue on windows touch devices that caused non-left clicks on collection view cells to be interpreted as left clicks.

## BMCollectionViewDataSource

A new `BMCollectionViewDataSource` interface may be implemented by objects, replacing the previous `BMCollectionViewDataSet` interface which is now deprecated. The data source interface defines the same methods as the previous data set interface, except for all previously deprecated methods which are now removed. In addition, the data source interface uses the delegate pattern so that all methods now receive the calling collection view as their first argument, allowing a single data source to be used with multiple collection views.

## BMCollectionViewFlowLayout

The static `flowLayout` factory method will now correctly return a subclass instance when inherited.

## BMCollectionViewMasonryLayout

The static `masonryLayout` factory method will now correctly return a subclass instance when inherited.

## BMCollectionViewStackLayout

The static `stackLayout` factory method will now correctly return a subclass instance when inherited.

## BMCollectionViewTileLayout

The static `tileLayout` factory method will now correctly return a subclass instance when inherited.

## BMMonacoCodeEditor

Resolves an issue with the monaco config where import statements written in typescript were converted into require calls.